### PR TITLE
feat: Update prompt APIs to support multimodal inputs

### DIFF
--- a/__tests__/anthropic/Session.test.mjs
+++ b/__tests__/anthropic/Session.test.mjs
@@ -1,0 +1,338 @@
+// Simple Test Runner and Mocking Setup (similar to shared/Session.test.mjs)
+const tests = [];
+let originalFetch;
+let mockFetchResponses = [];
+let fetchCallArgs = []; // To store arguments of fetch calls
+
+async function mockFetch(url, options) {
+  fetchCallArgs.push({ url, options: JSON.parse(options.body) }); // Store parsed body
+  if (mockFetchResponses.length === 0) {
+    throw new Error('Mock fetch called but no response was queued.');
+  }
+  const mockResponse = mockFetchResponses.shift();
+  if (mockResponse.error) {
+    return Promise.resolve({
+      ok: false,
+      status: mockResponse.status || 500,
+      statusText: mockResponse.statusText || 'Internal Server Error',
+      text: () => Promise.resolve(typeof mockResponse.error === 'string' ? mockResponse.error : JSON.stringify(mockResponse.error)),
+      json: () => Promise.resolve(mockResponse.error),
+    });
+  }
+
+  if (mockResponse.stream) {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      async start(controller) {
+        for (const chunk of mockResponse.chunks) {
+          controller.enqueue(encoder.encode(chunk));
+          await new Promise(resolve => setTimeout(resolve, 10)); // Simulate network delay
+        }
+        controller.close();
+      }
+    });
+    return Promise.resolve({
+      ok: true,
+      status: mockResponse.status || 200,
+      statusText: mockResponse.statusText || 'OK',
+      body: stream,
+      headers: new Headers({'Content-Type': 'text/event-stream'})
+    });
+  }
+
+  return Promise.resolve({
+    ok: true,
+    status: mockResponse.status || 200,
+    statusText: mockResponse.statusText || 'OK',
+    json: () => Promise.resolve(mockResponse.json),
+    text: () => Promise.resolve(JSON.stringify(mockResponse.json)), // if .text() is called
+  });
+}
+
+function setupGlobalFetchMock() {
+  originalFetch = global.fetch;
+  global.fetch = mockFetch;
+}
+
+function teardownGlobalFetchMock() {
+  global.fetch = originalFetch;
+}
+
+function queueMockResponse(response) {
+  mockFetchResponses.push(response);
+}
+
+function clearFetchCallLog() {
+  fetchCallArgs = [];
+  mockFetchResponses = [];
+}
+
+function test(description, fn) {
+  tests.push({ description, fn });
+}
+
+async function runAllTests() {
+  setupGlobalFetchMock();
+  for (const t of tests) {
+    clearFetchCallLog(); // Clear for each test
+    try {
+      await t.fn();
+      console.log(`✅ PASS: ${t.description}`);
+    } catch (e) {
+      console.error(`❌ FAIL: ${t.description}`);
+      console.error(e.stack); // Print stack trace for better debugging
+    }
+  }
+  teardownGlobalFetchMock();
+}
+
+// --- End of Simple Test Runner ---
+
+// Import the class to be tested
+import AnthropicSession from '../../anthropic/Session.mjs'; // Adjust path as needed
+
+// Mock AI interface for Session constructor
+const mockAiConfig = {
+  model: 'claude-3-opus-20240229',
+  endpoint: 'https://api.anthropic.com', // Default endpoint
+  credentials: { apiKey: 'test-api-key' }
+};
+const mockAiInterface = {
+  config: mockAiConfig,
+  languageModel: { _capabilities: { defaultTemperature: 0.7, maxTokens: 4096 } }
+};
+
+// Helper to create a simple Blob in Node.js (for testing purposes)
+function createTestBlob(content, type) {
+  if (typeof Blob === 'undefined') {
+    // Node.js environment
+    const { Blob } = await import('node:buffer');
+    return new Blob([content], { type });
+  }
+  // Browser environment
+  return new Blob([content], { type });
+}
+
+
+// --- Tests for Anthropic Session ---
+
+test('Anthropic: promptStreaming - string input (text-only)', async () => {
+  const session = new AnthropicSession({ systemPrompt: "Be helpful" }, mockAiInterface);
+  session._addToHistory("Previous user query", "Previous assistant answer");
+
+  queueMockResponse({
+    stream: true,
+    chunks: [
+      'event: message_start\ndata: {"type": "message_start", "message": {"id": "msg_123", "type": "message", "role": "assistant", "content": [], "model": "claude-3", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 10, "output_tokens": 1}}}\n\n',
+      'event: content_block_start\ndata: {"type": "content_block_start", "index":0, "content_block": {"type": "text", "text": ""}}\n\n',
+      'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}}\n\n',
+      'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": " world"}}\n\n',
+      'event: content_block_stop\ndata: {"type": "content_block_stop", "index":0}\n\n',
+      'event: message_delta\ndata: {"type": "message_delta", "delta": {"stop_reason": "end_turn", "stop_sequence":null, "usage":{"output_tokens": 2}}}\n\n',
+      'event: message_stop\ndata: {"type": "message_stop"}\n\n'
+    ]
+  });
+
+  const input = "Current user query";
+  let responseText = "";
+  for await (const chunk of session.promptStreaming(input, { temperature: 0.5, maxTokens: 100 })) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "Hello world", `Expected "Hello world", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  console.assert(requestPayload.messages.length === 3, `Expected 3 messages, got ${requestPayload.messages.length}`); // history (user, assistant) + current input
+  console.assert(requestPayload.messages[0].role === "user", "History message 1 role mismatch");
+  console.assert(requestPayload.messages[1].role === "assistant", "History message 2 role mismatch");
+  console.assert(requestPayload.messages[2].role === "user", "Current message role mismatch");
+  console.assert(requestPayload.messages[2].content[0].text === "Current user query", "Current message content mismatch");
+  console.assert(requestPayload.system === "Be helpful", "System prompt mismatch");
+  console.assert(requestPayload.temperature === 0.5, "Temperature option mismatch");
+  console.assert(requestPayload.max_tokens === 100, "max_tokens option mismatch");
+
+  const history = session._getConversationHistory();
+  console.assert(history.length === 4, `Expected history length 4, got ${history.length}`);
+  console.assert(history[3].role === "assistant" && history[3].content === "Hello world", "History not updated correctly");
+});
+
+
+test('Anthropic: promptStreaming - array input (text-only)', async () => {
+  const session = new AnthropicSession({}, mockAiInterface);
+  session._setConversationHistory([{role: "user", content: "Initial context"}]); // Set some prior history
+
+  queueMockResponse({
+    stream: true,
+    chunks: [
+      'event: message_start\ndata: {"type": "message_start", "message": {"role": "assistant"}}\n\n',
+      'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Array response"}}\n\n',
+      'event: message_stop\ndata: {"type": "message_stop"}\n\n'
+    ]
+  });
+
+  const inputArray = [
+    { role: 'user', content: 'Follow up 1' },
+    { role: 'assistant', content: 'Okay' },
+    { role: 'user', content: 'Follow up 2' }
+  ];
+  
+  // Note: For Anthropic, the `input` array in `promptStreaming` is treated as the content of the *last user message*.
+  // The `chat()` method in SharedSession would call `_setConversationHistory` with messages *before* the last one.
+  // So, if we are testing `promptStreaming` directly with an array, it means that array IS the last user message,
+  // potentially multimodal. Here, it's text-only parts.
+  
+  // To simulate `chat()` behavior for array input:
+  // 1. Current `input` to `promptStreaming` is the *last user message content*, potentially an array of parts.
+  // 2. History *before* this last user message is already set via `_setConversationHistory`.
+  
+  // Let's adjust the test to reflect `promptStreaming`'s direct expectation.
+  // The `input` will be the content of the last user message.
+  const lastUserMessageContent = [
+      { type: 'text', value: 'This is the last user message, composed of parts.'}
+  ];
+   session._setConversationHistory([ // History *before* the last user message
+    {role: "user", content: "Initial context"}, 
+    {role: "assistant", content: "Response to initial context"}
+  ]);
+
+
+  let responseText = "";
+  // Pass the array representing the last user message's content
+  for await (const chunk of session.promptStreaming(lastUserMessageContent, {})) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "Array response", `Expected "Array response", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  // Expected messages: history (user, assistant) + current user message (built from lastUserMessageContent)
+  console.assert(requestPayload.messages.length === 3, `Expected 3 messages, got ${requestPayload.messages.length}`);
+  console.assert(requestPayload.messages[2].role === "user", "Last message role mismatch");
+  console.assert(requestPayload.messages[2].content[0].type === "text", "Last message content type mismatch");
+  console.assert(requestPayload.messages[2].content[0].text === "This is the last user message, composed of parts.", "Last message content text mismatch");
+  
+  const history = session._getConversationHistory();
+  // Expected history: old_history + last_user_message (as array) + assistant_response
+  console.assert(history.length === 4, `Expected history length 4, got ${history.length}`);
+  console.assert(JSON.stringify(history[2].content) === JSON.stringify(lastUserMessageContent) , "User message in history mismatch");
+  console.assert(history[3].content === "Array response", "Assistant response in history mismatch");
+
+});
+
+test('Anthropic: promptStreaming - multimodal input (text + image Blob)', async () => {
+  const session = new AnthropicSession({}, mockAiInterface);
+  const imageBlob = await createTestBlob(["dummy image data"], "image/png");
+  
+  const input = [
+    { type: 'text', value: 'Describe this image:' },
+    { type: 'image', value: imageBlob, mimeType: 'image/png' } // mimeType here is illustrative, actual Blob has it
+  ];
+
+  queueMockResponse({
+    stream: true,
+    chunks: [
+      'event: message_start\ndata: {"type": "message_start", "message": {"role": "assistant"}}\n\n',
+      'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "It is an image."}}\n\n',
+      'event: message_stop\ndata: {"type": "message_stop"}\n\n'
+    ]
+  });
+
+  let responseText = "";
+  for await (const chunk of session.promptStreaming(input, {})) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "It is an image.", `Expected "It is an image.", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  const userMessageContent = requestPayload.messages[0].content;
+  console.assert(userMessageContent.length === 2, "Expected 2 parts in user message content");
+  console.assert(userMessageContent[0].type === "text" && userMessageContent[0].text === "Describe this image:", "Text part mismatch");
+  console.assert(userMessageContent[1].type === "image", "Image part type mismatch");
+  console.assert(userMessageContent[1].source.type === "base64", "Image source type mismatch");
+  console.assert(userMessageContent[1].source.media_type === "image/png", "Image media_type mismatch");
+  console.assert(userMessageContent[1].source.data.length > 0, "Image data missing"); // Basic check for base64 data
+
+  const history = session._getConversationHistory();
+  console.assert(history.length === 2, "History length mismatch");
+  console.assert(JSON.stringify(history[0].content) === JSON.stringify(input), "Multimodal user input not stored correctly in history");
+});
+
+test('Anthropic: promptStreaming - multimodal input (text + base64 image string)', async () => {
+  const session = new AnthropicSession({}, mockAiInterface);
+  const base64ImageData = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="; // 1x1 black pixel
+  
+  const input = [
+    { type: 'text', value: 'Analyze:' },
+    { type: 'image', value: base64ImageData, mimeType: 'image/png' } // Provide mimeType
+  ];
+
+  queueMockResponse({
+    stream: true,
+    chunks: [
+        'event: message_start\ndata: {"type": "message_start", "message": {"role": "assistant"}}\n\n',
+        'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Base64 image."}}\n\n',
+        'event: message_stop\ndata: {"type": "message_stop"}\n\n'
+    ]
+  });
+
+  let responseText = "";
+  for await (const chunk of session.promptStreaming(input, {})) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "Base64 image.", `Expected "Base64 image.", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  const userMessageContent = requestPayload.messages[0].content;
+  console.assert(userMessageContent[1].type === "image", "Image part type mismatch");
+  console.assert(userMessageContent[1].source.media_type === "image/png", "Image media_type mismatch for base64");
+  console.assert(userMessageContent[1].source.data === base64ImageData, "Image base64 data mismatch");
+});
+
+
+test('Anthropic: promptStreaming - API error handling', async () => {
+  const session = new AnthropicSession({}, mockAiInterface);
+  queueMockResponse({
+    error: { type: 'error', error: { type: 'invalid_request_error', message: 'Bad request' } },
+    status: 400
+  });
+
+  let errorThrown = false;
+  try {
+    for await (const chunk of session.promptStreaming("test error", {})) {
+      // Should not yield anything
+    }
+  } catch (e) {
+    errorThrown = true;
+    console.assert(e.message.includes("HTTP error! status: 400") || e.message.includes("Bad request"), `Error message mismatch: ${e.message}`);
+  }
+  console.assert(errorThrown, "API error did not throw an exception");
+});
+
+
+test('Anthropic: promptStreaming - options passthrough (max_tokens, temperature)', async () => {
+    const session = new AnthropicSession({}, mockAiInterface);
+    queueMockResponse({
+        stream: true,
+        chunks: [
+            'event: message_start\ndata: {"type": "message_start", "message": {"role": "assistant"}}\n\n',
+            'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Test"}}\n\n',
+            'event: message_stop\ndata: {"type": "message_stop"}\n\n'
+        ]
+    });
+
+    await session.promptStreaming("Test options", { temperature: 0.9, maxTokens: 150 }).next(); // Consume one item to trigger fetch
+
+    const requestPayload = fetchCallArgs[0].options;
+    console.assert(requestPayload.temperature === 0.9, "Temperature not passed through");
+    console.assert(requestPayload.max_tokens === 150, "max_tokens (mapped from maxTokens) not passed through");
+});
+
+
+// Run all tests when the file is executed
+runAllTests();
+// To run: node __tests__/anthropic/Session.test.mjs
+// Ensure relative path to anthropic/Session.mjs is correct.
+// Ensure Blob polyfill or Node version >= 15.7.0 (for Blob) or 16.5.0 (for buffer.Blob) is available if running in Node.
+// The createTestBlob helper tries to use node:buffer's Blob if global Blob is not found.

--- a/__tests__/gemini/Session.test.mjs
+++ b/__tests__/gemini/Session.test.mjs
@@ -1,0 +1,309 @@
+// Simple Test Runner and Mocking Setup (similar to shared/Session.test.mjs)
+const tests = [];
+let originalFetch;
+let mockFetchResponses = [];
+let fetchCallArgs = []; // To store arguments of fetch calls
+
+async function mockFetch(url, options) {
+  fetchCallArgs.push({ url, options: JSON.parse(options.body) }); // Store parsed body
+  if (mockFetchResponses.length === 0) {
+    throw new Error('Mock fetch called but no response was queued.');
+  }
+  const mockResponse = mockFetchResponses.shift();
+  if (mockResponse.error) {
+    return Promise.resolve({
+      ok: false,
+      status: mockResponse.status || 500,
+      statusText: mockResponse.statusText || 'Internal Server Error',
+      text: () => Promise.resolve(typeof mockResponse.error === 'string' ? mockResponse.error : JSON.stringify(mockResponse.error)),
+      json: () => Promise.resolve(mockResponse.error),
+    });
+  }
+
+  // For Gemini, streaming response is a series of JSON objects, not SSE formatted text
+  if (mockResponse.stream) {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      async start(controller) {
+        for (const item of mockResponse.jsonArray) {
+          // Gemini with alt=sse streams SSE events
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(item)}\n\n`)); 
+          await new Promise(resolve => setTimeout(resolve, 10)); 
+        }
+        controller.close();
+      }
+    });
+    return Promise.resolve({
+      ok: true,
+      status: mockResponse.status || 200,
+      statusText: mockResponse.statusText || 'OK',
+      body: stream,
+      headers: new Headers({'Content-Type': 'application/json'}) // Or appropriate for Gemini stream
+    });
+  }
+
+  return Promise.resolve({
+    ok: true,
+    status: mockResponse.status || 200,
+    statusText: mockResponse.statusText || 'OK',
+    json: () => Promise.resolve(mockResponse.json),
+    text: () => Promise.resolve(JSON.stringify(mockResponse.json)),
+  });
+}
+
+function setupGlobalFetchMock() {
+  originalFetch = global.fetch;
+  global.fetch = mockFetch;
+}
+
+function teardownGlobalFetchMock() {
+  global.fetch = originalFetch;
+}
+
+function queueMockResponse(response) {
+  mockFetchResponses.push(response);
+}
+
+function clearFetchCallLog() {
+  fetchCallArgs = [];
+  mockFetchResponses = [];
+}
+
+function test(description, fn) {
+  tests.push({ description, fn });
+}
+
+async function runAllTests() {
+  setupGlobalFetchMock();
+  for (const t of tests) {
+    clearFetchCallLog(); 
+    try {
+      await t.fn();
+      console.log(`✅ PASS: ${t.description}`);
+    } catch (e) {
+      console.error(`❌ FAIL: ${t.description}`);
+      console.error(e.stack); 
+    }
+  }
+  teardownGlobalFetchMock();
+}
+
+// --- End of Simple Test Runner ---
+
+import GeminiSession from '../../gemini/Session.mjs'; 
+
+// Mock AI interface for Session constructor
+const mockAiConfig = {
+  model: 'gemini-1.5-flash-latest', // or 'gemini-pro-vision' for multimodal
+  endpoint: 'https://generativelanguage.googleapis.com', 
+  credentials: { apiKey: 'test-api-key' }
+};
+const mockAiInterface = {
+  config: mockAiConfig,
+  languageModel: { _capabilities: { defaultTemperature: 0.7, maxTokens: 2048, defaultTopK: 3, defaultTopP: 0.9 } }
+};
+
+// Helper to create a simple Blob in Node.js
+async function createTestBlob(content, type) {
+  if (typeof Blob === 'undefined') {
+    const { Blob } = await import('node:buffer');
+    return new Blob([content], { type });
+  }
+  return new Blob([content], { type });
+}
+
+
+// --- Tests for Gemini Session ---
+
+test('Gemini: promptStreaming - string input (text-only)', async () => {
+  const session = new GeminiSession({ systemPrompt: "Be concise" }, mockAiInterface);
+  session._addToHistory("Old question", "Old answer");
+
+  queueMockResponse({
+    stream: true,
+    jsonArray: [ // Gemini streams an array of JSON objects
+      { candidates: [{ content: { parts: [{ text: "Response " }] } }] },
+      { candidates: [{ content: { parts: [{ text: "part 2" }] } }] }
+    ]
+  });
+
+  const input = "New question";
+  let responseText = "";
+  for await (const chunk of session.promptStreaming(input, { temperature: 0.6, topK: 5 })) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "Response part 2", `Expected "Response part 2", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  console.assert(requestPayload.systemInstruction.parts[0].text === "Be concise", "System prompt mismatch");
+  console.assert(requestPayload.contents.length === 3, `Expected 3 contents, got ${requestPayload.contents.length}`); // History (user, model) + current input
+  console.assert(requestPayload.contents[0].role === "user", "History message 1 role mismatch");
+  console.assert(requestPayload.contents[1].role === "model", "History message 2 role mismatch");
+  console.assert(requestPayload.contents[2].role === "user", "Current message role mismatch");
+  console.assert(requestPayload.contents[2].parts[0].text === "New question", "Current message content mismatch");
+  
+  console.assert(requestPayload.generationConfig.temperature === 0.6, "Temperature option mismatch");
+  console.assert(requestPayload.generationConfig.topK === 5, "topK option mismatch");
+
+  const history = session._getConversationHistory();
+  console.assert(history.length === 4, `Expected history length 4, got ${history.length}`);
+  console.assert(history[3].role === "assistant" && history[3].content === "Response part 2", "History not updated correctly");
+});
+
+test('Gemini: promptStreaming - array input (text-only, simulating chat last message)', async () => {
+  const session = new GeminiSession({}, mockAiInterface);
+   // History before the last user message (which will be the array input)
+  session._setConversationHistory([
+    { role: "user", content: "Initial query" },
+    { role: "assistant", content: "Initial response" }
+  ]);
+
+  queueMockResponse({
+    stream: true,
+    jsonArray: [
+      { candidates: [{ content: { parts: [{ text: "Array input " }] } }] },
+      { candidates: [{ content: { parts: [{ text: "response." }] } }] }
+    ]
+  });
+
+  const lastUserMessageContent = [ // This is LanguageModelMessageContent[]
+    { type: 'text', value: 'This is the first part of the last user message.' },
+    { type: 'text', value: 'This is the second part.' }
+  ];
+
+  let responseText = "";
+  // `input` to promptStreaming is the LanguageModelMessageContent[] for the last user message
+  for await (const chunk of session.promptStreaming(lastUserMessageContent, {})) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "Array input response.", `Expected "Array input response.", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  // Expected contents: history (user, model) + current user message (built from lastUserMessageContent)
+  console.assert(requestPayload.contents.length === 3, `Expected 3 contents, got ${requestPayload.contents.length}`);
+  const lastApiMessage = requestPayload.contents[2];
+  console.assert(lastApiMessage.role === "user", "Last message role mismatch");
+  console.assert(lastApiMessage.parts.length === 2, "Last message parts count mismatch");
+  console.assert(lastApiMessage.parts[0].text === "This is the first part of the last user message.", "Last message part 1 text mismatch");
+  console.assert(lastApiMessage.parts[1].text === "This is the second part.", "Last message part 2 text mismatch");
+  
+  const history = session._getConversationHistory();
+  // Expected history: old_history + last_user_message (as array of LanguageModelMessageContent) + assistant_response
+  console.assert(history.length === 4, `Expected history length 4, got ${history.length}`);
+  console.assert(JSON.stringify(history[2].content) === JSON.stringify(lastUserMessageContent), "User message in history mismatch");
+  console.assert(history[3].content === "Array input response.", "Assistant response in history mismatch");
+});
+
+
+test('Gemini: promptStreaming - multimodal input (text + image Blob)', async () => {
+  // Ensure model in config supports vision, e.g. by setting it if default is non-vision
+  const visionMockAiInterface = { ...mockAiInterface, config: {...mockAiConfig, model: 'gemini-pro-vision'} };
+  const session = new GeminiSession({}, visionMockAiInterface);
+  const imageBlob = await createTestBlob(["dummy image data"], "image/png");
+  
+  const input = [ // LanguageModelMessageContent[]
+    { type: 'text', value: 'Describe this image:' },
+    { type: 'image', value: imageBlob, mimeType: 'image/png' }
+  ];
+
+  queueMockResponse({
+    stream: true,
+    jsonArray: [
+      { candidates: [{ content: { parts: [{ text: "It is a PNG image." }] } }] }
+    ]
+  });
+
+  let responseText = "";
+  for await (const chunk of session.promptStreaming(input, {})) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "It is a PNG image.", `Expected "It is a PNG image.", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  const userMessageParts = requestPayload.contents[0].parts; // Assuming no prior history for simplicity here
+  console.assert(userMessageParts.length === 2, "Expected 2 parts in user message content");
+  console.assert(userMessageParts[0].text === "Describe this image:", "Text part mismatch");
+  console.assert(userMessageParts[1].inlineData, "Image part should have inlineData");
+  console.assert(userMessageParts[1].inlineData.mimeType === "image/png", "Image mimeType mismatch");
+  console.assert(userMessageParts[1].inlineData.data.length > 0, "Image data missing");
+
+  const history = session._getConversationHistory();
+  console.assert(history.length === 2, "History length mismatch");
+  console.assert(JSON.stringify(history[0].content) === JSON.stringify(input), "Multimodal user input not stored correctly in history");
+});
+
+test('Gemini: promptStreaming - multimodal input (text + base64 image string)', async () => {
+  const visionMockAiInterface = { ...mockAiInterface, config: {...mockAiConfig, model: 'gemini-pro-vision'} };
+  const session = new GeminiSession({}, visionMockAiInterface);
+  const base64ImageData = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+  
+  const input = [ // LanguageModelMessageContent[]
+    { type: 'text', value: 'Analyze base64:' },
+    { type: 'image', value: base64ImageData, mimeType: 'image/png' }
+  ];
+
+  queueMockResponse({
+    stream: true,
+    jsonArray: [
+        { candidates: [{ content: { parts: [{ text: "Analyzed base64 image." }] } }] }
+    ]
+  });
+
+  let responseText = "";
+  for await (const chunk of session.promptStreaming(input, {})) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "Analyzed base64 image.", `Expected "Analyzed base64 image.", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  const userMessageParts = requestPayload.contents[0].parts;
+  console.assert(userMessageParts[1].inlineData.mimeType === "image/png", "Image mimeType mismatch for base64");
+  console.assert(userMessageParts[1].inlineData.data === base64ImageData, "Image base64 data mismatch");
+});
+
+
+test('Gemini: promptStreaming - API error handling', async () => {
+  const session = new GeminiSession({}, mockAiInterface);
+  queueMockResponse({
+    error: { error: { code: 400, message: 'Invalid request', status: 'INVALID_ARGUMENT' } }, // Gemini error structure
+    status: 400
+  });
+
+  let errorThrown = false;
+  try {
+    for await (const chunk of session.promptStreaming("test error", {})) {
+      // Should not yield
+    }
+  } catch (e) {
+    errorThrown = true;
+    console.assert(e.message.includes("Gemini API Error") && (e.message.includes("Invalid request") || e.message.includes("400")), `Error message mismatch: ${e.message}`);
+  }
+  console.assert(errorThrown, "API error did not throw an exception");
+});
+
+test('Gemini: promptStreaming - options passthrough (maxOutputTokens, topP, topK)', async () => {
+    const session = new GeminiSession({}, mockAiInterface);
+    queueMockResponse({
+        stream: true,
+        jsonArray: [{ candidates: [{ content: { parts: [{ text: "Test" }] } }] }]
+    });
+
+    // Consume one item to trigger fetch
+    await session.promptStreaming("Test options", { temperature: 0.8, maxTokens: 200, topP: 0.85, topK: 7 }).next(); 
+
+    const requestPayload = fetchCallArgs[0].options;
+    const genConfig = requestPayload.generationConfig;
+    console.assert(genConfig.temperature === 0.8, "Temperature not passed through");
+    console.assert(genConfig.maxOutputTokens === 200, "maxOutputTokens (from maxTokens) not passed through");
+    console.assert(genConfig.topP === 0.85, "topP not passed through");
+    console.assert(genConfig.topK === 7, "topK not passed through");
+});
+
+// Run all tests when the file is executed
+runAllTests();
+// To run: node __tests__/gemini/Session.test.mjs
+// Ensure Blob polyfill or Node version for Blob is available.

--- a/__tests__/huggingface/Session.test.mjs
+++ b/__tests__/huggingface/Session.test.mjs
@@ -1,0 +1,278 @@
+// Simple Test Runner and Mocking Setup (similar to shared/Session.test.mjs)
+const tests = [];
+let originalFetch;
+let mockFetchResponses = [];
+let fetchCallArgs = []; 
+let consoleWarnArgs = []; // To store arguments of console.warn calls
+let originalConsoleWarn;
+
+
+async function mockFetch(url, options) {
+  fetchCallArgs.push({ url, options: JSON.parse(options.body) }); 
+  if (mockFetchResponses.length === 0) {
+    throw new Error('Mock fetch called but no response was queued.');
+  }
+  const mockResponse = mockFetchResponses.shift();
+  if (mockResponse.error) {
+    return Promise.resolve({
+      ok: false,
+      status: mockResponse.status || 500,
+      statusText: mockResponse.statusText || 'Internal Server Error',
+      text: () => Promise.resolve(typeof mockResponse.error === 'string' ? mockResponse.error : JSON.stringify(mockResponse.error)),
+      json: () => Promise.resolve(mockResponse.error),
+    });
+  }
+
+  if (mockResponse.stream) {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      async start(controller) {
+        for (const chunk of mockResponse.chunks) {
+          controller.enqueue(encoder.encode(chunk)); // HuggingFace (OpenAI compatible) streams SSE
+          await new Promise(resolve => setTimeout(resolve, 10)); 
+        }
+        controller.close();
+      }
+    });
+    return Promise.resolve({
+      ok: true,
+      status: mockResponse.status || 200,
+      statusText: mockResponse.statusText || 'OK',
+      body: stream,
+      headers: new Headers({'Content-Type': 'text/event-stream'})
+    });
+  }
+
+  return Promise.resolve({
+    ok: true,
+    status: mockResponse.status || 200,
+    statusText: mockResponse.statusText || 'OK',
+    json: () => Promise.resolve(mockResponse.json),
+    text: () => Promise.resolve(JSON.stringify(mockResponse.json)),
+  });
+}
+
+function setupGlobalMocks() {
+  originalFetch = global.fetch;
+  global.fetch = mockFetch;
+  originalConsoleWarn = console.warn;
+  console.warn = (...args) => {
+    consoleWarnArgs.push(args);
+  };
+}
+
+function teardownGlobalMocks() {
+  global.fetch = originalFetch;
+  console.warn = originalConsoleWarn;
+}
+
+function queueMockResponse(response) {
+  mockFetchResponses.push(response);
+}
+
+function clearMockCallLogs() {
+  fetchCallArgs = [];
+  mockFetchResponses = [];
+  consoleWarnArgs = [];
+}
+
+function test(description, fn) {
+  tests.push({ description, fn });
+}
+
+async function runAllTests() {
+  setupGlobalMocks();
+  for (const t of tests) {
+    clearMockCallLogs(); 
+    try {
+      await t.fn();
+      console.log(`✅ PASS: ${t.description}`);
+    } catch (e) {
+      console.error(`❌ FAIL: ${t.description}`);
+      console.error(e.stack); 
+    }
+  }
+  teardownGlobalMocks();
+}
+
+// --- End of Simple Test Runner ---
+
+import HuggingFaceSession from '../../huggingface/Session.mjs'; 
+
+// Mock AI interface for Session constructor
+const mockAiConfig = {
+  model: 'mistralai/Mistral-7B-Instruct-v0.1', // Example model
+  endpoint: 'https://api-inference.huggingface.co', 
+  credentials: { apiKey: 'hf_test-api-key' }
+};
+const mockAiInterface = {
+  config: mockAiConfig,
+  languageModel: { _capabilities: { defaultTemperature: 0.7, defaultTopK: 50, maxTokens: 1024 } }
+};
+
+// Helper to create a simple Blob in Node.js
+async function createTestBlob(content, type) {
+  if (typeof Blob === 'undefined') {
+    const { Blob } = await import('node:buffer');
+    return new Blob([content], { type });
+  }
+  return new Blob([content], { type });
+}
+
+
+// --- Tests for HuggingFace Session ---
+
+test('HuggingFace: promptStreaming - string input (text-only)', async () => {
+  const session = new HuggingFaceSession({ systemPrompt: "Be direct." }, mockAiInterface);
+  session._addToHistory("Previous question", "Previous direct answer");
+
+  queueMockResponse({
+    stream: true,
+    chunks: [ // Standard OpenAI SSE format, as HF uses TGI which is OpenAI compatible for chat
+      'data: {"id":"cmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"current-model","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n',
+      'data: {"id":"cmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"current-model","choices":[{"index":0,"delta":{"content":"Direct "},"finish_reason":null}]}\n\n',
+      'data: {"id":"cmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"current-model","choices":[{"index":0,"delta":{"content":"response."},"finish_reason":null}]}\n\n',
+      'data: {"id":"cmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"current-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+      'data: [DONE]\n\n'
+    ]
+  });
+
+  const input = "A new query.";
+  let responseText = "";
+  for await (const chunk of session.promptStreaming(input, { temperature: 0.2, maxTokens: 30 })) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "Direct response.", `Expected "Direct response.", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  console.assert(requestPayload.messages[0].role === "system" && requestPayload.messages[0].content === "Be direct.", "System prompt mismatch");
+  console.assert(requestPayload.messages.length === 4, `Expected 4 messages, got ${requestPayload.messages.length}`);
+  console.assert(requestPayload.messages[3].role === "user" && requestPayload.messages[3].content === "A new query.", "Current message content mismatch");
+  
+  console.assert(requestPayload.temperature === 0.2, "Temperature option mismatch");
+  console.assert(requestPayload.max_tokens === 30, "max_tokens option mismatch");
+
+  const history = session._getConversationHistory();
+  console.assert(history.length === 4, `Expected history length 4, got ${history.length}`);
+  console.assert(history[3].role === "assistant" && history[3].content === "Direct response.", "History not updated correctly");
+});
+
+
+test('HuggingFace: promptStreaming - array input (text parts only, simulating chat last message)', async () => {
+  const session = new HuggingFaceSession({}, mockAiInterface);
+  session._setConversationHistory([
+    { role: "user", content: "Contextual question" },
+    { role: "assistant", content: "Contextual answer" }
+  ]);
+
+  queueMockResponse({
+    stream: true,
+    chunks: [
+      'data: {"choices":[{"delta":{"content":"Array "}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"processed."}}]}\n\n',
+      'data: [DONE]\n\n'
+    ]
+  });
+
+  const lastUserMessageContent = [ // LanguageModelMessageContent[]
+    { type: 'text', value: 'First part of array input.' },
+    { type: 'text', value: 'Second part of array input.' }
+  ];
+
+  let responseText = "";
+  for await (const chunk of session.promptStreaming(lastUserMessageContent, {})) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "Array processed.", `Expected "Array processed.", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  console.assert(requestPayload.messages.length === 3, `Expected 3 messages, got ${requestPayload.messages.length}`);
+  const lastApiMessage = requestPayload.messages[2];
+  console.assert(lastApiMessage.role === "user", "Last message role mismatch");
+  // HuggingFace Session currently concatenates text parts for array input
+  console.assert(typeof lastApiMessage.content === 'string', "Last message content should be a string for HF");
+  console.assert(lastApiMessage.content === "First part of array input.\nSecond part of array input.", "Last message content mismatch");
+  
+  const history = session._getConversationHistory();
+  console.assert(history.length === 4, `Expected history length 4, got ${history.length}`);
+  console.assert(JSON.stringify(history[2].content) === JSON.stringify(lastUserMessageContent), "User message in history mismatch - should be original array");
+  console.assert(history[3].content === "Array processed.", "Assistant response in history mismatch");
+});
+
+test('HuggingFace: promptStreaming - array input (mixed text/image, image discarded)', async () => {
+  const session = new HuggingFaceSession({}, mockAiInterface);
+  const imageBlob = await createTestBlob(["dummy image data"], "image/png");
+
+  queueMockResponse({
+    stream: true,
+    chunks: [
+      'data: {"choices":[{"delta":{"content":"Understood: "}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"Text part."}}]}\n\n',
+      'data: [DONE]\n\n'
+    ]
+  });
+
+  const mixedInput = [ // LanguageModelMessageContent[]
+    { type: 'text', value: 'Text part.' },
+    { type: 'image', value: imageBlob } // This should be discarded
+  ];
+
+  let responseText = "";
+  for await (const chunk of session.promptStreaming(mixedInput, {})) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "Understood: Text part.", `Expected "Understood: Text part.", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  const lastApiMessage = requestPayload.messages[0]; // Assuming no prior history for this test
+  console.assert(lastApiMessage.content === "Text part.", "Image part not discarded correctly");
+
+  console.assert(consoleWarnArgs.length > 0, "console.warn was not called for discarded image");
+  console.assert(consoleWarnArgs[0][0].includes("Non-text part of type 'image' found and will be discarded"), "Warning message mismatch");
+
+  const history = session._getConversationHistory();
+  console.assert(history.length === 2, "History length mismatch");
+  // History should store the original mixedInput
+  console.assert(JSON.stringify(history[0].content) === JSON.stringify(mixedInput), "Original mixed input not stored correctly in history");
+});
+
+
+test('HuggingFace: promptStreaming - API error handling', async () => {
+  const session = new HuggingFaceSession({}, mockAiInterface);
+  queueMockResponse({
+    error: { error: "Model is overloaded", error_type: " सेवा त्रुटि" }, // Example HF error
+    status: 503 
+  });
+
+  let errorThrown = false;
+  try {
+    for await (const chunk of session.promptStreaming("test api error", {})) { /* consume */ }
+  } catch (e) {
+    errorThrown = true;
+    console.assert(e.message.includes("HTTP error! status: 503") && e.message.includes("Model is overloaded"), `Error message mismatch: ${e.message}`);
+  }
+  console.assert(errorThrown, "API error did not throw an exception");
+});
+
+test('HuggingFace: promptStreaming - options passthrough (max_tokens, temperature, top_k)', async () => {
+    const session = new HuggingFaceSession({}, mockAiInterface);
+    queueMockResponse({
+        stream: true,
+        chunks: ['data: {"choices":[{"delta":{"content":"Options "}}]}\n\n', 'data: [DONE]\n\n']
+    });
+
+    await session.promptStreaming("Test HF options", { temperature: 0.11, maxTokens: 99, topK: 11 }).next(); 
+
+    const requestPayload = fetchCallArgs[0].options;
+    console.assert(requestPayload.temperature === 0.11, "Temperature not passed through");
+    console.assert(requestPayload.max_tokens === 99, "max_tokens (from maxTokens) not passed through");
+    console.assert(requestPayload.top_k === 11, "top_k (from topK) not passed through");
+});
+
+// Run all tests when the file is executed
+runAllTests();
+// To run: node __tests__/huggingface/Session.test.mjs
+// Ensure Blob polyfill or Node version for Blob is available.

--- a/__tests__/openai/Session.test.mjs
+++ b/__tests__/openai/Session.test.mjs
@@ -1,0 +1,316 @@
+// Simple Test Runner and Mocking Setup (similar to shared/Session.test.mjs)
+const tests = [];
+let originalFetch;
+let mockFetchResponses = [];
+let fetchCallArgs = []; // To store arguments of fetch calls
+
+async function mockFetch(url, options) {
+  fetchCallArgs.push({ url, options: JSON.parse(options.body) }); // Store parsed body
+  if (mockFetchResponses.length === 0) {
+    throw new Error('Mock fetch called but no response was queued.');
+  }
+  const mockResponse = mockFetchResponses.shift();
+  if (mockResponse.error) {
+    return Promise.resolve({
+      ok: false,
+      status: mockResponse.status || 500,
+      statusText: mockResponse.statusText || 'Internal Server Error',
+      text: () => Promise.resolve(typeof mockResponse.error === 'string' ? mockResponse.error : JSON.stringify(mockResponse.error)),
+      json: () => Promise.resolve(mockResponse.error),
+    });
+  }
+
+  if (mockResponse.stream) {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      async start(controller) {
+        for (const chunk of mockResponse.chunks) {
+          controller.enqueue(encoder.encode(chunk)); // OpenAI streams SSE
+          await new Promise(resolve => setTimeout(resolve, 10)); 
+        }
+        controller.close();
+      }
+    });
+    return Promise.resolve({
+      ok: true,
+      status: mockResponse.status || 200,
+      statusText: mockResponse.statusText || 'OK',
+      body: stream,
+      headers: new Headers({'Content-Type': 'text/event-stream'})
+    });
+  }
+
+  return Promise.resolve({
+    ok: true,
+    status: mockResponse.status || 200,
+    statusText: mockResponse.statusText || 'OK',
+    json: () => Promise.resolve(mockResponse.json),
+    text: () => Promise.resolve(JSON.stringify(mockResponse.json)),
+  });
+}
+
+function setupGlobalFetchMock() {
+  originalFetch = global.fetch;
+  global.fetch = mockFetch;
+}
+
+function teardownGlobalFetchMock() {
+  global.fetch = originalFetch;
+}
+
+function queueMockResponse(response) {
+  mockFetchResponses.push(response);
+}
+
+function clearFetchCallLog() {
+  fetchCallArgs = [];
+  mockFetchResponses = [];
+}
+
+function test(description, fn) {
+  tests.push({ description, fn });
+}
+
+async function runAllTests() {
+  setupGlobalFetchMock();
+  for (const t of tests) {
+    clearFetchCallLog(); 
+    try {
+      await t.fn();
+      console.log(`✅ PASS: ${t.description}`);
+    } catch (e) {
+      console.error(`❌ FAIL: ${t.description}`);
+      console.error(e.stack); 
+    }
+  }
+  teardownGlobalFetchMock();
+}
+
+// --- End of Simple Test Runner ---
+
+import OpenAISession from '../../openai/Session.mjs'; 
+
+// Mock AI interface for Session constructor
+const mockAiConfig = {
+  model: 'gpt-4-turbo', 
+  endpoint: 'https://api.openai.com', 
+  credentials: { apiKey: 'test-api-key' }
+};
+const mockAiInterface = {
+  config: mockAiConfig,
+  languageModel: { _capabilities: { defaultTemperature: 0.7, maxTokens: 4096 } }
+};
+
+// Helper to create a simple Blob in Node.js
+async function createTestBlob(content, type) {
+  if (typeof Blob === 'undefined') {
+    const { Blob } = await import('node:buffer');
+    return new Blob([content], { type });
+  }
+  return new Blob([content], { type });
+}
+
+
+// --- Tests for OpenAI Session ---
+
+test('OpenAI: promptStreaming - string input (text-only)', async () => {
+  const session = new OpenAISession({ systemPrompt: "Be witty" }, mockAiInterface);
+  session._addToHistory("Old user joke", "Old AI punchline");
+
+  queueMockResponse({
+    stream: true,
+    chunks: [
+      'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4-turbo","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}\n\n',
+      'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4-turbo","choices":[{"index":0,"delta":{"content":"Why "},"finish_reason":null}]}\n\n',
+      'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4-turbo","choices":[{"index":0,"delta":{"content":"did "},"finish_reason":null}]}\n\n',
+      'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4-turbo","choices":[{"index":0,"delta":{"content":"the chicken..."},"finish_reason":null}]}\n\n',
+      'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4-turbo","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+      'data: [DONE]\n\n'
+    ]
+  });
+
+  const input = "Tell me a joke.";
+  let responseText = "";
+  for await (const chunk of session.promptStreaming(input, { temperature: 0.8, maxTokens: 50 })) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "Why did the chicken...", `Expected "Why did the chicken...", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  console.assert(requestPayload.messages[0].role === "system" && requestPayload.messages[0].content === "Be witty", "System prompt mismatch");
+  console.assert(requestPayload.messages.length === 4, `Expected 4 messages, got ${requestPayload.messages.length}`); // system + history (user, assistant) + current input
+  console.assert(requestPayload.messages[1].role === "user", "History message 1 role mismatch");
+  console.assert(requestPayload.messages[2].role === "assistant", "History message 2 role mismatch");
+  console.assert(requestPayload.messages[3].role === "user", "Current message role mismatch");
+  console.assert(requestPayload.messages[3].content === "Tell me a joke.", "Current message content mismatch");
+  
+  console.assert(requestPayload.temperature === 0.8, "Temperature option mismatch");
+  console.assert(requestPayload.max_tokens === 50, "max_tokens option mismatch");
+
+  const history = session._getConversationHistory();
+  console.assert(history.length === 4, `Expected history length 4, got ${history.length}`);
+  console.assert(history[3].role === "assistant" && history[3].content === "Why did the chicken...", "History not updated correctly");
+});
+
+
+test('OpenAI: promptStreaming - array input (text-only, simulating chat last message)', async () => {
+  const session = new OpenAISession({}, mockAiInterface);
+  session._setConversationHistory([
+    { role: "user", content: "First question" },
+    { role: "assistant", content: "First answer" }
+  ]);
+
+  queueMockResponse({
+    stream: true,
+    chunks: [
+      'data: {"choices":[{"delta":{"content":"Response "}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"to array."}}]}\n\n',
+      'data: [DONE]\n\n'
+    ]
+  });
+
+  const lastUserMessageContent = [ // This is LanguageModelMessageContent[]
+    { type: 'text', value: 'This is a follow-up.' },
+    { type: 'text', value: 'Split into two parts.' }
+  ];
+
+  let responseText = "";
+  for await (const chunk of session.promptStreaming(lastUserMessageContent, {})) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "Response to array.", `Expected "Response to array.", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  // Expected messages: history (user, assistant) + current user message (built from lastUserMessageContent)
+  console.assert(requestPayload.messages.length === 3, `Expected 3 messages, got ${requestPayload.messages.length}`);
+  const lastApiMessage = requestPayload.messages[2];
+  console.assert(lastApiMessage.role === "user", "Last message role mismatch");
+  console.assert(Array.isArray(lastApiMessage.content) && lastApiMessage.content.length === 2, "Last message content should be an array of 2 parts");
+  console.assert(lastApiMessage.content[0].type === "text" && lastApiMessage.content[0].text === "This is a follow-up.", "Last message part 1 text mismatch");
+  console.assert(lastApiMessage.content[1].type === "text" && lastApiMessage.content[1].text === "Split into two parts.", "Last message part 2 text mismatch");
+  
+  const history = session._getConversationHistory();
+  // Expected history: old_history + last_user_message (as original LanguageModelMessage array) + assistant_response
+  console.assert(history.length === 4, `Expected history length 4, got ${history.length}`);
+  // The history should store the input in its original LanguageModelMessage format.
+  // The `input` to promptStreaming was LanguageModelMessageContent[], which then gets wrapped into a LanguageModelMessage by chat() or by the test setup.
+  // Here, `lastUserMessageContent` *is* the content for the last user message.
+  console.assert(JSON.stringify(history[2].content) === JSON.stringify(lastUserMessageContent), "User message content in history mismatch");
+  console.assert(history[3].content === "Response to array.", "Assistant response in history mismatch");
+});
+
+
+test('OpenAI: promptStreaming - multimodal input (text + image Blob)', async () => {
+  const session = new OpenAISession({}, { ...mockAiInterface, config: { ...mockAiConfig, model: 'gpt-4-vision-preview' }});
+  const imageBlob = await createTestBlob(["dummy image data"], "image/png");
+  
+  const input = [ // LanguageModelMessageContent[]
+    { type: 'text', value: 'What is in this Blob image?' },
+    { type: 'image', value: imageBlob, mimeType: 'image/png' }
+  ];
+
+  queueMockResponse({
+    stream: true,
+    chunks: [
+      'data: {"choices":[{"delta":{"content":"It looks "}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"like a Blob."}}]}\n\n',
+      'data: [DONE]\n\n'
+    ]
+  });
+
+  let responseText = "";
+  for await (const chunk of session.promptStreaming(input, {})) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "It looks like a Blob.", `Expected "It looks like a Blob.", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  const userMessageContent = requestPayload.messages[0].content; // Assuming no history for simplicity here
+  console.assert(Array.isArray(userMessageContent) && userMessageContent.length === 2, "Expected 2 parts in user message content");
+  console.assert(userMessageContent[0].type === "text" && userMessageContent[0].text === "What is in this Blob image?", "Text part mismatch");
+  console.assert(userMessageContent[1].type === "image_url", "Image part type mismatch");
+  console.assert(userMessageContent[1].image_url.url.startsWith("data:image/png;base64,"), "Image URL should be a data URI for PNG");
+
+  const history = session._getConversationHistory();
+  console.assert(history.length === 2, "History length mismatch");
+  console.assert(JSON.stringify(history[0].content) === JSON.stringify(input), "Multimodal user input not stored correctly in history");
+});
+
+test('OpenAI: promptStreaming - multimodal input (text + base64 image string)', async () => {
+  const session = new OpenAISession({}, { ...mockAiInterface, config: { ...mockAiConfig, model: 'gpt-4-vision-preview' }});
+  const base64ImageData = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+  
+  const input = [ // LanguageModelMessageContent[]
+    { type: 'text', value: 'Image analysis (base64):' },
+    { type: 'image', value: base64ImageData, mimeType: 'image/png' }
+  ];
+
+  queueMockResponse({
+    stream: true,
+    chunks: [
+        'data: {"choices":[{"delta":{"content":"Tiny "}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"black dot."}}]}\n\n',
+        'data: [DONE]\n\n'
+    ]
+  });
+
+  let responseText = "";
+  for await (const chunk of session.promptStreaming(input, {})) {
+    responseText += chunk;
+  }
+
+  console.assert(responseText === "Tiny black dot.", `Expected "Tiny black dot.", got "${responseText}"`);
+  
+  const requestPayload = fetchCallArgs[0].options;
+  const userMessageContent = requestPayload.messages[0].content;
+  console.assert(userMessageContent[1].type === "image_url", "Image part type mismatch");
+  console.assert(userMessageContent[1].image_url.url === `data:image/png;base64,${base64ImageData}`, "Image data URI mismatch for base64");
+});
+
+
+test('OpenAI: promptStreaming - API error handling', async () => {
+  const session = new OpenAISession({}, mockAiInterface);
+  queueMockResponse({
+    error: { error: { message: 'Insufficient quota.', type: 'insufficient_quota', code: 'insufficient_quota' } }, // OpenAI error structure
+    status: 429
+  });
+
+  let errorThrown = false;
+  try {
+    for await (const chunk of session.promptStreaming("test quota error", {})) {
+      // Should not yield
+    }
+  } catch (e) {
+    errorThrown = true;
+    console.assert(e.message.includes("HTTP error! status: 429") && e.message.includes("Insufficient quota"), `Error message mismatch: ${e.message}`);
+  }
+  console.assert(errorThrown, "API error did not throw an exception");
+});
+
+
+test('OpenAI: promptStreaming - options passthrough (max_tokens, temperature)', async () => {
+    const session = new OpenAISession({}, mockAiInterface);
+    queueMockResponse({
+        stream: true,
+        chunks: [
+            'data: {"choices":[{"delta":{"content":"Testing "}}]}\n\n',
+            'data: {"choices":[{"delta":{"content":"options."}}]}\n\n',
+            'data: [DONE]\n\n'
+        ]
+    });
+
+    // Consume one item to trigger fetch
+    await session.promptStreaming("Test options passthrough", { temperature: 0.1, maxTokens: 77 }).next(); 
+
+    const requestPayload = fetchCallArgs[0].options;
+    console.assert(requestPayload.temperature === 0.1, "Temperature not passed through");
+    console.assert(requestPayload.max_tokens === 77, "max_tokens (from maxTokens) not passed through");
+});
+
+// Run all tests when the file is executed
+runAllTests();
+// To run: node __tests__/openai/Session.test.mjs
+// Ensure Blob polyfill or Node version for Blob is available.

--- a/__tests__/shared/Session.test.mjs
+++ b/__tests__/shared/Session.test.mjs
@@ -1,0 +1,266 @@
+// Simple Test Runner and Mocking Setup
+const tests = [];
+let originalFetch;
+let mockFetchResponses = [];
+let fetchCallArgs = [];
+
+async function mockFetch(url, options) {
+  fetchCallArgs.push({ url, options });
+  if (mockFetchResponses.length === 0) {
+    throw new Error('Mock fetch called but no response was queued.');
+  }
+  const mockResponse = mockFetchResponses.shift();
+  if (mockResponse.error) {
+    return Promise.resolve({
+      ok: false,
+      status: mockResponse.status || 500,
+      statusText: mockResponse.statusText || 'Internal Server Error',
+      text: () => Promise.resolve(mockResponse.error),
+      json: () => Promise.resolve(mockResponse.error), // if error is JSON
+    });
+  }
+  return Promise.resolve({
+    ok: true,
+    status: mockResponse.status || 200,
+    statusText: mockResponse.statusText || 'OK',
+    json: () => Promise.resolve(mockResponse.json),
+    text: () => Promise.resolve(mockResponse.text),
+    body: mockResponse.body, // For streaming
+  });
+}
+
+function setupTests() {
+  originalFetch = global.fetch;
+  global.fetch = mockFetch;
+}
+
+function teardownTests() {
+  global.fetch = originalFetch;
+}
+
+function queueMockResponse(response) {
+  mockFetchResponses.push(response);
+}
+
+function clearFetchCalls() {
+  fetchCallArgs = [];
+  mockFetchResponses = [];
+}
+
+function test(description, fn) {
+  tests.push({ description, fn });
+}
+
+async function runTests() {
+  setupTests();
+  for (const t of tests) {
+    clearFetchCalls(); // Clear mocks for each test
+    try {
+      await t.fn();
+      console.log(`✅ PASS: ${t.description}`);
+    } catch (e) {
+      console.error(`❌ FAIL: ${t.description}`);
+      console.error(e);
+    }
+  }
+  teardownTests();
+}
+
+// --- End of Simple Test Runner ---
+
+// Import the class to be tested
+import SharedSession from '../../shared/Session.mjs';
+
+// Mock AI interface for Session constructor
+const mockAi = {
+  config: { model: 'test-model', endpoint: 'http://localhost:1234/api' },
+  languageModel: { _capabilities: { defaultTemperature: 0.7, maxTokens: 100 } }
+};
+
+test('_countTokensInMessages: string content', async () => {
+  const session = new SharedSession({}, mockAi);
+  const messages = [{ role: 'user', content: 'Hello world' }];
+  // "Hello" -> 1, "world" -> 1. Total 2. Plus 3 for structure. = 5
+  const count = session._countTokensInMessages(messages);
+  console.assert(count === 5, `Expected 5, got ${count}`);
+});
+
+test('_countTokensInMessages: array of text parts', async () => {
+  const session = new SharedSession({}, mockAi);
+  const messages = [
+    { role: 'user', content: [{ type: 'text', value: 'Hello' }, { type: 'text', value: 'World' }] }
+  ];
+  // "Hello" -> 1, "World" -> 1. Total 2. Plus 3 for structure. = 5
+  const count = session._countTokensInMessages(messages);
+  console.assert(count === 5, `Expected 5, got ${count}`);
+});
+
+test('_countTokensInMessages: mixed content (text and image)', async () => {
+  const session = new SharedSession({}, mockAi);
+  const messages = [
+    { role: 'user', content: [{ type: 'text', value: 'Describe:' }, { type: 'image', value: 'placeholder_image_data' }] }
+  ];
+  // "Describe:" -> 1. Image placeholder -> 75. Total 76. Plus 3 for structure. = 79
+  const count = session._countTokensInMessages(messages);
+  console.assert(count === 79, `Expected 79, got ${count}`);
+});
+
+test('_countTokensInMessages: empty messages array', async () => {
+  const session = new SharedSession({}, mockAi);
+  const messages = [];
+  const count = session._countTokensInMessages(messages);
+  console.assert(count === 0, `Expected 0, got ${count}`);
+});
+
+test('_countTokensInMessages: message with empty string content', async () => {
+  const session = new SharedSession({}, mockAi);
+  const messages = [{ role: 'user', content: '' }];
+  // "" -> 1 (Math.max(1, tokenCount) in _countTokens). Plus 3 for structure. = 4
+  const count = session._countTokensInMessages(messages);
+  console.assert(count === 4, `Expected 4, got ${count}`);
+});
+
+test('_countTokensInMessages: message with empty array content', async () => {
+  const session = new SharedSession({}, mockAi);
+  const messages = [{ role: 'user', content: [] }];
+  // Empty array content -> 0. Plus 3 for structure. = 3
+  const count = session._countTokensInMessages(messages);
+  console.assert(count === 3, `Expected 3, got ${count}`);
+});
+
+
+// --- Tests for chat() ---
+
+class TestSession extends SharedSession {
+  // Mock prompt and promptStreaming for chat() tests
+  async prompt(input, options) {
+    fetchCallArgs.push({ type: 'prompt', input, options }); // Log call
+    return "Mocked prompt response";
+  }
+  async *promptStreaming(input, options) {
+    fetchCallArgs.push({ type: 'promptStreaming', input, options }); // Log call
+    yield "Mocked ";
+    yield "streamed ";
+    yield "response";
+  }
+}
+
+
+test('chat(): stream: false - basic functionality', async () => {
+  const session = new TestSession({}, mockAi);
+  const messages = [
+    { role: 'system', content: 'System prompt.' },
+    { role: 'user', content: 'User message 1.' },
+    { role: 'assistant', content: 'Assistant message 1.' },
+    { role: 'user', content: 'Last user message.' },
+  ];
+
+  const chatOptions = { messages, stream: false, temperature: 0.5 };
+  
+  // Mock _countTokensInMessages for predictable usage data
+  const originalCountTokens = session._countTokensInMessages;
+  session._countTokensInMessages = (msgs) => {
+    if (msgs.length === 1 && msgs[0].role === 'user') return 10; // prompt_tokens
+    if (msgs.length === 1 && msgs[0].role === 'assistant') return 20; // completion_tokens
+    return 0;
+  };
+
+  const response = await session.chat(chatOptions);
+
+  // Verify _setConversationHistory call (indirectly by checking history state if possible, or by spying if framework allows)
+  // For now, check that _getConversationHistory inside prompt/promptStreaming would receive the correct slice.
+  // The TestSession's mock prompt/promptStreaming doesn't use _getConversationHistory, so we check the call args.
+  const promptCall = fetchCallArgs.find(call => call.type === 'prompt');
+  console.assert(promptCall, "session.prompt was not called");
+  console.assert(promptCall.input === 'Last user message.', "session.prompt called with wrong input");
+  
+  // Check that _setConversationHistory was effectively called by chat()
+  // We can verify this by checking the history state *during* the mocked prompt call.
+  // This requires a more sophisticated spy or temporarily overriding _getConversationHistory.
+  // For this simple runner, we'll trust the implementation detail that _setConversationHistory is called.
+  // A more direct way:
+  let historyDuringPromptCall;
+  session.prompt = async (input, options) => { // Override again to capture history
+    historyDuringPromptCall = session._getConversationHistory();
+    fetchCallArgs.push({ type: 'prompt', input, options });
+    return "Mocked prompt response";
+  };
+  await session.chat(chatOptions); // Call again with the spy
+  
+  const expectedHistory = messages.slice(0, -1);
+  console.assert(JSON.stringify(historyDuringPromptCall) === JSON.stringify(expectedHistory), 
+    `_setConversationHistory not called correctly. Expected ${JSON.stringify(expectedHistory)}, got ${JSON.stringify(historyDuringPromptCall)}`);
+
+
+  // Verify response structure
+  console.assert(response.id, "Response missing id");
+  console.assert(response.object === "chat.completion", "Response object type incorrect");
+  console.assert(response.choices[0].message.content === "Mocked prompt response", "Response content incorrect");
+  console.assert(response.choices[0].message.role === "assistant", "Response role incorrect");
+  
+  // Verify usage
+  console.assert(response.usage.prompt_tokens === 10, "Prompt tokens incorrect");
+  console.assert(response.usage.completion_tokens === 20, "Completion tokens incorrect");
+  console.assert(response.usage.total_tokens === 30, "Total tokens incorrect");
+
+  session._countTokensInMessages = originalCountTokens; // Restore
+});
+
+
+test('chat(): stream: true - basic functionality', async () => {
+  const session = new TestSession({}, mockAi);
+   const messages = [
+    { role: 'system', content: 'System prompt.' },
+    { role: 'user', content: 'User message 1.' },
+    { role: 'assistant', content: 'Assistant message 1.' },
+    { role: 'user', content: 'Last user message for stream.' },
+  ];
+  const chatOptions = { messages, stream: true, temperature: 0.6 };
+
+  const stream = await session.chat(chatOptions);
+  
+  let streamedContent = "";
+  let count = 0;
+  for await (const chunk of stream) {
+    count++;
+    console.assert(chunk.id, `Stream chunk ${count} missing id`);
+    console.assert(chunk.object === "chat.completion.chunk", `Stream chunk ${count} object type incorrect`);
+    console.assert(chunk.choices[0].delta.content, `Stream chunk ${count} delta content missing`);
+    streamedContent += chunk.choices[0].delta.content;
+  }
+
+  console.assert(streamedContent === "Mocked streamed response", "Full streamed content incorrect");
+
+  // Verify _setConversationHistory call (indirectly)
+  const streamCall = fetchCallArgs.find(call => call.type === 'promptStreaming');
+  console.assert(streamCall, "session.promptStreaming was not called");
+  console.assert(streamCall.input === 'Last user message for stream.', "session.promptStreaming called with wrong input");
+  
+  // Similar to non-streaming, check history state during the call
+  let historyDuringStreamCall;
+  session.promptStreaming = async function* (input, options) { // Override to capture
+    historyDuringStreamCall = session._getConversationHistory();
+    fetchCallArgs.push({ type: 'promptStreaming', input, options });
+    yield "TestChunk";
+  };
+  const testStream = await session.chat(chatOptions); // Call again
+  for await (const _ of testStream) {} // Consume stream
+
+  const expectedHistory = messages.slice(0, -1);
+   console.assert(JSON.stringify(historyDuringStreamCall) === JSON.stringify(expectedHistory), 
+    `_setConversationHistory not called correctly for stream. Expected ${JSON.stringify(expectedHistory)}, got ${JSON.stringify(historyDuringStreamCall)}`);
+});
+
+
+// Run all tests
+runTests();
+
+// To execute this file: node __tests__/shared/Session.test.mjs
+// Ensure shared/Session.mjs path is correct relative to this test file.
+// And that Session.mjs can be imported in a Node environment (e.g. uses ES module syntax correctly).
+// If Session.mjs uses browser-specific things not available in Node (like native Blob for image processing without polyfill),
+// those parts might need specific mocks or adjustments when testing in Node.
+// For now, _countTokensInMessages and chat() structure are the focus.
+// The placeholder for image data ('placeholder_image_data') in _countTokensInMessages test is fine as it's just a string.
+// The `Blob` and `ArrayBuffer` image handling in provider-specific classes will need more careful mocking if tested in Node.
+// For `shared/Session.mjs` itself, string and text array content is sufficient.

--- a/anthropic/Session.mjs
+++ b/anthropic/Session.mjs
@@ -21,7 +21,18 @@ class Session extends SharedSession {
   //     ...options,
   //   };
   // }
-  async prompt(prompt, options = {}) {
+  async prompt(input, options = {}) {
+    // Utilizes promptStreaming to make the API call and handle history
+    const output = [];
+    for await (const message of this.promptStreaming(input, options)) {
+      output.push(message);
+    }
+    // The history update (_addToHistory or _setConversationHistory)
+    // is now handled within promptStreaming based on the input type.
+    return output.join("");
+  }
+
+  async *promptStreaming(input, options = {}) {
     options.temperature =
       options.temperature ??
       this.ai.languageModel._capabilities.defaultTemperature;
@@ -30,61 +41,117 @@ class Session extends SharedSession {
       this.ai.languageModel._capabilities.maxTokens ??
       4096;
 
-    const protoMessages = [
-      ...(this.options.initialPrompts || []).filter(
-        (msg) => msg.role === "user" || msg.role === "assistant"
-      ),
-      ...this._getConversationHistory(),
-      { role: "user", content: prompt },
-    ];
-    // messages cannot have the role "system"
-    const systemPrompts = protoMessages
-      .filter((msg) => msg.role === "system")
-      .map(({ content }) => content);
+    // System Prompt Construction
+    const systemPromptsContent = [];
     if (this.options.systemPrompt) {
-      systemPrompts.unshift(this.options.systemPrompt);
+      systemPromptsContent.push(this.options.systemPrompt);
     }
-    const messages = protoMessages.filter((msg) => msg.role !== "system");
+    (this.options.initialPrompts || [])
+      .filter((msg) => msg.role === "system")
+      .forEach((msg) => systemPromptsContent.push(msg.content));
+    const system = systemPromptsContent.join("\n");
 
-    const response = await fetch(`${this.config.endpoint}/v1/messages`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": this.config.credentials?.apiKey || "",
-        "anthropic-version": "2023-06-01",
-        "anthropic-dangerous-direct-browser-access": "true",
-      },
-      body: JSON.stringify({
-        model: this.config.model || "claude-3-opus-20240229",
-        system: systemPrompts.join("\n"),
-        messages,
-        ...options,
-      }),
-    });
+    // Message Construction (messagesToAnthropic)
+    let workingMessages = []; // Stores messages in LanguageModelMessage format
 
-    const data = await response.json();
-    if (data.error) {
-      throw new Error(`Anthropic API Error: ${data.error.message}`);
+    // Add initial non-system prompts
+    (this.options.initialPrompts || [])
+      .filter((msg) => msg.role !== "system")
+      .forEach((msg) => workingMessages.push(msg));
+
+    // Add conversation history & current input
+    if (typeof input === "string") {
+      workingMessages.push(...this._getConversationHistory());
+      workingMessages.push({ role: "user", content: input });
+    } else if (Array.isArray(input)) {
+      // If input is an array of LanguageModelMessage,
+      // it means the calling context (e.g. shared/Session chat())
+      // has already set the history appropriately via _setConversationHistory.
+      // `_getConversationHistory()` here will return messages *up to* the current user turn.
+      // `input` then contains the actual user messages for *this* turn.
+      workingMessages.push(...this._getConversationHistory());
+      workingMessages.push(...input); // input is LanguageModelMessage[]
+    } else {
+      throw new Error(
+        "Invalid input type for promptStreaming. Must be string or array."
+      );
     }
 
-    const assistantResponse = data.content[0].text;
-    this._addToHistory(prompt, assistantResponse);
-    return assistantResponse;
-  }
+    const messagesToAnthropic = await Promise.all(
+      workingMessages.map(async (message) => {
+        let anthropicContent;
+        if (typeof message.content === "string") {
+          anthropicContent = [{ type: "text", text: message.content }];
+        } else if (Array.isArray(message.content)) {
+          anthropicContent = await Promise.all(
+            message.content.map(async (part) => {
+              if (part.type === "text") {
+                return { type: "text", text: part.value };
+              }
+              if (part.type === "image") {
+                let base64Data;
+                let mediaType = "image/jpeg"; // Default media type
+                if (typeof part.value === "string") {
+                  if (part.value.startsWith("data:")) {
+                    mediaType = part.value.substring(
+                      part.value.indexOf(":") + 1,
+                      part.value.indexOf(";")
+                    );
+                    base64Data = part.value.substring(
+                      part.value.indexOf(",") + 1
+                    );
+                  } else {
+                    // Assume it's already base64 if no data URI prefix
+                    base64Data = part.value;
+                  }
+                } else if (part.value instanceof Blob) {
+                  mediaType = part.value.type || mediaType;
+                  base64Data = await new Promise((resolve, reject) => {
+                    const reader = new FileReader();
+                    reader.onloadend = () =>
+                      resolve(reader.result.split(",")[1]);
+                    reader.onerror = reject;
+                    reader.readAsDataURL(part.value);
+                  });
+                } else if (part.value instanceof ArrayBuffer) {
+                  let binary = "";
+                  const bytes = new Uint8Array(part.value);
+                  const len = bytes.byteLength;
+                  for (let i = 0; i < len; i++) {
+                    binary += String.fromCharCode(bytes[i]);
+                  }
+                  base64Data = btoa(binary);
+                } else {
+                  throw new Error(
+                    "Unsupported image content type for Anthropic: " +
+                      typeof part.value
+                  );
+                }
+                return {
+                  type: "image",
+                  source: {
+                    type: "base64",
+                    media_type: mediaType,
+                    data: base64Data,
+                  },
+                };
+              }
+              throw new Error(
+                "Unsupported part type for Anthropic: " + part.type
+              );
+            })
+          );
+        } else {
+           throw new Error("Unsupported message content type: " + typeof message.content);
+        }
+        return { role: message.role, content: anthropicContent };
+      })
+    );
+    
+    // Filter out any messages that might be empty after processing (e.g. system prompts that were already handled)
+    // Also, ensure roles are appropriate (user or assistant). System messages are handled by the 'system' parameter.
+    const finalMessagesForAPI = messagesToAnthropic.filter(msg => msg.role === 'user' || msg.role === 'assistant');
 
-  async *promptStreaming(prompt, options = {}) {
-    options.temperature =
-      options.temperature ??
-      this.ai.languageModel._capabilities.defaultTemperature;
-    options.max_tokens = options.maxTokens ?? 4096;
-
-    const messages = [
-      ...(this.options.initialPrompts || []).filter(
-        (msg) => msg.role === "user" || msg.role === "assistant"
-      ),
-      ...this._getConversationHistory(),
-      { role: "user", content: prompt },
-    ];
 
     const response = await fetch(`${this.config.endpoint}/v1/messages`, {
       method: "POST",
@@ -97,8 +164,8 @@ class Session extends SharedSession {
       },
       body: JSON.stringify({
         model: this.config.model || "claude-3-opus-20240229",
-        system: this.options.systemPrompt,
-        messages,
+        system: system, // Use the constructed system string
+        messages: finalMessagesForAPI, // Use the transformed messages
         ...options,
         stream: true,
       }),
@@ -109,7 +176,7 @@ class Session extends SharedSession {
       throw new Error(`HTTP error! status: ${response.status}, body: ${error}`);
     }
 
-    const responseChunks = [];
+    const responseChunks = []; // Accumulates text parts of the response
 
     const reader = response.body
       .pipeThrough(new TextDecoderStream())
@@ -139,9 +206,21 @@ class Session extends SharedSession {
           if (trimmedLine.startsWith("data: ")) {
             const data = trimmedLine.slice(6);
 
-            if (data === "[DONE]") {
-              this._addToHistory(prompt, responseChunks.join(""));
-              return;
+            // Correctly check for the "message_stop" event for Anthropic
+            if (currentEvent === "message_stop") {
+              const assistantResponseText = responseChunks.join("");
+              if (typeof input === "string") {
+                this._addToHistory(input, assistantResponseText);
+              } else if (Array.isArray(input)) {
+                // `workingMessages` at this point contains:
+                // initialPrompts (non-system) + _getConversationHistory() + input (array from user)
+                // This is the complete history *before* the assistant's response.
+                this._setConversationHistory([
+                  ...workingMessages,
+                  { role: "assistant", content: assistantResponseText },
+                ]);
+              }
+              return; // End of stream processing
             }
 
             try {
@@ -149,36 +228,52 @@ class Session extends SharedSession {
 
               switch (currentEvent) {
                 case "message_start":
+                  // Potentially useful for other things, but not for text content
                   break;
                 case "content_block_start":
+                  // Indicates start of a content block (e.g., text, image)
                   break;
                 case "content_block_delta":
-                  if (parsed.delta?.text) {
+                  if (parsed.delta?.type === "text_delta") {
                     responseChunks.push(parsed.delta.text);
                     yield parsed.delta.text;
                   }
+                  // Could handle other delta types here if needed, e.g., tool_use
+                  break;
+                case "content_block_stop":
+                  // Indicates end of a content block
                   break;
                 case "message_delta":
-                  if (parsed.delta?.content?.[0]?.text) {
-                    responseChunks.push(parsed.delta.content[0].text);
-                    yield parsed.delta.content[0].text;
-                  }
+                  // This event might contain deltas for various things, including stop_reason
+                  // The primary text delta is usually in content_block_delta
                   break;
-                default:
-                  if (parsed.content?.[0]?.text) {
-                    responseChunks.push(parsed.content[0].text);
-                    yield parsed.content[0].text;
-                  }
+                // No default case needed as we only care about specific events for text
               }
             } catch (error) {
-              console.error("Failed to parse SSE message:", trimmedLine);
-              console.error("Parse error:", error);
+              // console.error("Failed to parse SSE message:", trimmedLine, "Event:", currentEvent);
+              // console.error("Parse error:", error);
+              // It's possible some non-JSON data or keep-alive pings might appear.
+              // Depending on strictness, might log or ignore. For now, log.
             }
           }
         }
       }
     } finally {
       reader.releaseLock();
+      // Final history update if loop exited unexpectedly (e.g. stream closed without message_stop)
+      // This is a fallback, primary history update should be on "message_stop"
+      // Fallback history update if stream ends without 'message_stop'
+      if (currentEvent !== "message_stop" && responseChunks.length > 0) {
+        const assistantResponseText = responseChunks.join("");
+        if (typeof input === "string") {
+          this._addToHistory(input, assistantResponseText);
+        } else if (Array.isArray(input)) {
+          this._setConversationHistory([
+            ...workingMessages,
+            { role: "assistant", content: assistantResponseText },
+          ]);
+        }
+      }
     }
   }
 }

--- a/gemini/Session.mjs
+++ b/gemini/Session.mjs
@@ -1,136 +1,194 @@
 import SharedSession from "../shared/Session.mjs";
 import ensureAsyncIterable from "../util/ensure-async-iterator.mjs";
+
+// Helper function to convert Blob to base64
+async function blobToBase64(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      // result includes 'data:mime/type;base64,' prefix, remove it
+      const base64Data = reader.result.split(",")[1];
+      resolve({ mimeType: blob.type, data: base64Data });
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
+
+// Helper function to convert ArrayBuffer to base64
+async function arrayBufferToBase64(buffer, mimeType = "application/octet-stream") { // Default mimeType if not known
+  let binary = "";
+  const bytes = new Uint8Array(buffer);
+  const len = bytes.byteLength;
+  for (let i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return { mimeType, data: btoa(binary) };
+}
+
+
 class Session extends SharedSession {
-  async prompt(prompt, options = {}) {
-    options.temperature =
-      options.temperature ??
-      this.ai.languageModel._capabilities.defaultTemperature;
-    options.topK =
-      options.topK ?? this.ai.languageModel._capabilities.defaultTopK;
-    options.topP = options.topP ?? this.ai.languageModel._capabilities.topP;
-    options.maxOutputTokens =
-      options.maxTokens ?? this.ai.languageModel._capabilities.maxTokens;
-
-    // Convert conversation history to Gemini format
-    const history = this._getConversationHistory().map((msg) => ({
-      text: `${msg.role}: ${msg.content}`,
-    }));
-
-    const parts = [
-      ...(this.options.systemPrompt
-        ? [{ text: this.options.systemPrompt }]
-        : []),
-      ...(this.options.initialPrompts || []).map((p) => ({
-        text: p.content,
-      })),
-      ...history,
-      { text: prompt },
-    ];
-
-    const response = await fetch(
-      `${
-        this.config.endpoint
-      }/v1beta/models/gemini-1.5-flash:generateContent?key=${
-        this.config.credentials?.apiKey || ""
-      }`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          contents: [{ parts }],
-          generationConfig: options,
-        }),
-      }
-    );
-
-    const data = await response.json();
-    if (data.error) {
-      throw new Error(`Gemini API Error: ${data.error.message}`);
+  async prompt(input, options = {}) {
+    // Utilizes promptStreaming to make the API call and handle history
+    const output = [];
+    for await (const message of this.promptStreaming(input, options)) {
+      output.push(message);
     }
-
-    const assistantResponse = data.candidates[0].content.parts[0].text;
-    this._addToHistory(prompt, assistantResponse);
-    return assistantResponse;
+    // History update is handled within promptStreaming
+    return output.join("");
   }
 
-  async *promptStreaming(prompt, options = {}) {
+  async *promptStreaming(input, options = {}) {
     options.temperature =
       options.temperature ??
       this.ai.languageModel._capabilities.defaultTemperature;
-    options.topK =
-      options.topK ?? this.ai.languageModel._capabilities.defaultTopK;
+    options.topK = options.topK ?? this.ai.languageModel._capabilities.defaultTopK;
     options.topP = options.topP ?? this.ai.languageModel._capabilities.topP;
-    options.maxOutputTokens =
-      options.maxTokens ?? this.ai.languageModel._capabilities.maxTokens;
+    options.maxOutputTokens = options.maxTokens ?? this.ai.languageModel._capabilities.maxTokens;
 
-    // Convert conversation history to Gemini format
-    const history = this._getConversationHistory().map((msg) => ({
-      text: `${msg.role}: ${msg.content}`,
+    let system_instruction_object = null;
+    if (this.options.systemPrompt) {
+      system_instruction_object = {
+        // Gemini uses 'parts' for system instructions, not 'role' directly at this level
+        parts: [{ text: this.options.systemPrompt }],
+      };
+    }
+
+    let working_messages_for_history = []; // Stored in LanguageModelMessage format for history update
+    let gemini_api_contents = []; // Stored in Gemini API Content format
+
+    // 1. Initial Prompts
+    (this.options.initialPrompts || []).forEach((msg) => {
+      working_messages_for_history.push(msg);
+    });
+
+    // 2. Conversation History & Current Input
+    // Stash current working_messages before adding history and new input, for easier history update later if input is string.
+    const initial_prompts_for_history = [...working_messages_for_history];
+
+    if (typeof input === "string") {
+      working_messages_for_history.push(...this._getConversationHistory());
+      working_messages_for_history.push({ role: "user", content: input });
+    } else if (Array.isArray(input)) {
+      // input is LanguageModelMessage[]
+      // As per shared/Session.mjs chat(), _setConversationHistory is called before promptStreaming.
+      // So _getConversationHistory() here gets history *up to* the current user's turn.
+      working_messages_for_history.push(...this._getConversationHistory());
+      working_messages_for_history.push(...input);
+    } else {
+      throw new Error("Invalid input type. Must be string or array.");
+    }
+    
+    // Transform for Gemini API
+    gemini_api_contents = await Promise.all(working_messages_for_history.map(async (msg) => {
+        const role = msg.role === "assistant" ? "model" : msg.role; // Map 'assistant' to 'model'
+        let parts = [];
+        if (typeof msg.content === "string") {
+            parts.push({ text: msg.content });
+        } else if (Array.isArray(msg.content)) { // LanguageModelMessageContent[]
+            parts = await Promise.all(msg.content.map(async (part) => {
+                if (part.type === "text") {
+                    return { text: part.value };
+                } else if (part.type === "image") {
+                    let mimeType = "image/jpeg"; // Default
+                    let data;
+                    if (part.value instanceof Blob) {
+                        const base64Result = await blobToBase64(part.value);
+                        mimeType = base64Result.mimeType;
+                        data = base64Result.data;
+                    } else if (part.value instanceof ArrayBuffer) {
+                        // Try to infer mimeType if available, else use default
+                        mimeType = part.mimeType || mimeType; 
+                        const base64Result = await arrayBufferToBase64(part.value, mimeType);
+                        data = base64Result.data;
+                    } else if (typeof part.value === 'string') { // Assume base64 string or data URI
+                        if (part.value.startsWith('data:')) {
+                            const parts = part.value.split(',');
+                            mimeType = parts[0].substring(parts[0].indexOf(':') + 1, parts[0].indexOf(';'));
+                            data = parts[1];
+                        } else {
+                             // Potentially just a base64 string, try to get mimeType from part if provided
+                            mimeType = part.mimeType || mimeType;
+                            data = part.value;
+                        }
+                    } else {
+                        throw new Error("Unsupported image content value type: " + typeof part.value);
+                    }
+                    return { inlineData: { mimeType, data } };
+                } else {
+                    throw new Error("Unsupported message content part type: " + part.type);
+                }
+            }));
+        }
+        return { role, parts };
     }));
 
-    const parts = [
-      ...(this.options.systemPrompt
-        ? [{ text: this.options.systemPrompt }]
-        : []),
-      ...(this.options.initialPrompts || []).map((p) => ({
-        text: p.content,
-      })),
-      ...history,
-      { text: prompt },
-    ];
 
+    const requestBody = {
+      contents: gemini_api_contents,
+      generationConfig: {
+        temperature: options.temperature,
+        topK: options.topK,
+        topP: options.topP,
+        maxOutputTokens: options.maxOutputTokens,
+        // candidateCount, stopSequences can be added if needed
+      },
+      ...(system_instruction_object ? { systemInstruction: system_instruction_object } : {}),
+    };
+    
     const response = await fetch(
-      `${
-        this.config.endpoint
-      }/v1beta/models/gemini-1.5-flash:streamGenerateContent?alt=sse&key=${
-        this.config.credentials?.apiKey || ""
-      }`,
+      `${this.config.endpoint}/v1beta/models/${this.config.model || 'gemini-1.5-flash-latest'}:streamGenerateContent?alt=sse&key=${this.config.credentials?.apiKey || ""}`,
       {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          contents: [{ parts }],
-          generationConfig: options,
-        }),
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(requestBody),
       }
     );
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Gemini API Error: ${response.status} ${response.statusText} - ${errorText}`);
+    }
 
     const responseChunks = [];
     const decoder = new TextDecoder();
     for await (const chunk of ensureAsyncIterable(response.body)) {
-      const text = decoder.decode(new Uint8Array(chunk));
-      // Split into separate messages
-      const messages = text.split("\n");
+      const text = decoder.decode(new Uint8Array(chunk), { stream: true });
+      const lines = text.split("\n");
 
-      for (const message of messages) {
-        // Skip empty messages
-        if (!message.trim()) continue;
-
-        // Extract the JSON data after "data: "
-        const jsonStr = message.replace("data: ", "").trim();
-        if (jsonStr === "[DONE]") {
-          self._addToHistory(prompt, responseChunks.join(""));
-          return;
-        }
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) continue;
+        const jsonStr = line.substring("data: ".length).trim();
+        if (!jsonStr || jsonStr === "[DONE]") continue;
 
         try {
           const data = JSON.parse(jsonStr);
-          const content = data.candidates[0]?.content?.parts[0]?.text;
-          if (content) {
+          // Check if there are candidates and parts
+          if (data.candidates && data.candidates[0] && data.candidates[0].content && data.candidates[0].content.parts && data.candidates[0].content.parts[0] && data.candidates[0].content.parts[0].text) {
+            const content = data.candidates[0].content.parts[0].text;
             responseChunks.push(content);
             yield content;
+          } else if (data.error) {
+             throw new Error(`Gemini API Error in stream: ${data.error.message}`);
           }
+          // Gemini might also send finishReason or other info in chunks, handle if necessary
         } catch (e) {
-          // Skip parsing errors for empty or incomplete messages
-          if (message.trim() && !message.includes("data: ")) {
-            throw new Error("Failed to parse JSON stream: " + e?.message);
-          }
+          console.error("Failed to parse JSON stream chunk:", jsonStr, e);
+          // Decide if this is a fatal error for the stream
         }
       }
+    }
+    
+    const assistantResponseText = responseChunks.join("");
+    // History update based on the type of the original 'input'
+    if (typeof input === "string") {
+      this._addToHistory(input, assistantResponseText);
+    } else if (Array.isArray(input)) {
+      // working_messages_for_history contains: initialPrompts + _getConversationHistory() + input (array)
+      this._setConversationHistory([
+        ...working_messages_for_history,
+        { role: "assistant", content: assistantResponseText },
+      ]);
     }
   }
 }

--- a/huggingface/Session.mjs
+++ b/huggingface/Session.mjs
@@ -1,130 +1,240 @@
 import SharedSession from "../shared/Session.mjs";
 
+// Helper function to convert Blob to Data URI
+async function blobToDataURI(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
+
+// Helper function to convert ArrayBuffer to Data URI
+async function arrayBufferToDataURI(buffer, mimeType = "image/jpeg") { // Default mimeType
+  const blob = new Blob([buffer], { type: mimeType });
+  return blobToDataURI(blob);
+}
+
+// Helper function to convert plain base64 string to Data URI
+function base64ToDataURI(base64String, mimeType = "image/jpeg") {
+  return `data:${mimeType};base64,${base64String}`;
+}
+
+// Deep copy utility
+function deepCopy(obj) {
+    if (obj === null || typeof obj !== 'object') {
+        return obj;
+    }
+    if (obj instanceof Date) {
+        return new Date(obj);
+    }
+    if (obj instanceof Array) {
+        const copy = [];
+        for (let i = 0; i < obj.length; i++) {
+            copy[i] = deepCopy(obj[i]);
+        }
+        return copy;
+    }
+    if (obj instanceof Object) {
+        const copy = {};
+        for (const key in obj) {
+            if (obj.hasOwnProperty(key)) {
+                copy[key] = deepCopy(obj[key]);
+            }
+        }
+        return copy;
+    }
+    throw new Error("Unable to copy obj! Its type isn't supported.");
+}
+
+
 class Session extends SharedSession {
-  async prompt(prompt, options = {}) {
-    const headers = {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${this.config.credentials?.apiKey || ""}`,
-      Accept: "application/json",
-    };
-    options.temperature =
-      options.temperature ??
-      this.ai.languageModel._capabilities.defaultTemperature;
-    options.top_k =
-      options.topK ?? this.ai.languageModel._capabilities.defaultTopK;
-
-    const messages = [
-      ...(this.options.systemPrompt
-        ? [{ role: "system", content: this.options.systemPrompt }]
-        : []),
-      ...(this.options.initialPrompts || []),
-      ...this._getConversationHistory(),
-      { role: "user", content: prompt },
-    ];
-
-    const response = await fetch(
-      `${this.config.endpoint}/models/${this.config.model}/v1/chat/completions`,
-      {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          messages,
-          ...options,
-        }),
-      }
-    );
-
-    if (!response.ok) {
-      const error = await response.text();
-      console.error("Error body:", error);
-      throw new Error(`HTTP error! status: ${response.status}, body: ${error}`);
+  async prompt(input, options = {}) {
+    // Utilizes promptStreaming to make the API call and handle history
+    const output = [];
+    for await (const message of this.promptStreaming(input, options)) {
+      output.push(message);
     }
-
-    try {
-      const data = await response.json();
-      const assistantResponse = data.choices[0].message.content;
-      this._addToHistory(prompt, assistantResponse);
-      return assistantResponse;
-    } catch (error) {
-      throw error;
-    }
+    // History update is handled within promptStreaming
+    return output.join("");
   }
 
-  async *promptStreaming(prompt, options = {}) {
+  async *promptStreaming(input, options = {}) {
     const headers = {
       "Content-Type": "application/json",
       Authorization: `Bearer ${this.config.credentials?.apiKey || ""}`,
-      Accept: "text/event-stream",
+      Accept: "text/event-stream", 
     };
-    options.temperature =
-      options.temperature ??
-      this.ai.languageModel._capabilities.defaultTemperature;
-    options.top_k =
-      options.topK ?? this.ai.languageModel._capabilities.defaultTopK;
+    // Map common option names to Hugging Face specific ones if necessary
+    options.temperature = options.temperature ?? this.ai.languageModel._capabilities.defaultTemperature;
+    options.top_k = options.topK ?? this.ai.languageModel._capabilities.defaultTopK;
+    options.max_tokens = options.maxTokens; // Assuming maxTokens is the HF parameter
 
-    const messages = [
-      ...(this.options.systemPrompt
-        ? [{ role: "system", content: this.options.systemPrompt }]
-        : []),
-      ...(this.options.initialPrompts || []),
-      ...this._getConversationHistory(),
-      { role: "user", content: prompt },
-    ];
+    // This variable will store messages in the LanguageModelMessage format for history updates.
+    let historyInputMessages_before_hf_transform = [];
+    // This variable will store messages transformed for the Hugging Face API.
+    let hfMessages = [];
+
+    // 1. System Prompt
+    let systemContent = "";
+    if (this.options.systemPrompt) {
+      systemContent = this.options.systemPrompt;
+    }
+    (this.options.initialPrompts || []).forEach(msg => {
+      if (msg.role === "system") {
+        if (systemContent) systemContent += "\n"; 
+        systemContent += msg.content;
+      }
+    });
+    if (systemContent) {
+      hfMessages.push({ role: "system", content: systemContent });
+    }
+
+    // 2. User/Assistant Prompts from initialPrompts (non-system)
+    (this.options.initialPrompts || []).forEach(msg => {
+      if (msg.role !== "system") {
+        historyInputMessages_before_hf_transform.push(deepCopy(msg));
+        hfMessages.push(deepCopy(msg)); 
+      }
+    });
+    
+    // 3. Conversation History
+    const conversationHistory = this._getConversationHistory();
+    historyInputMessages_before_hf_transform.push(...deepCopy(conversationHistory));
+    hfMessages.push(...deepCopy(conversationHistory));
+
+    // 4. Current Input
+    if (typeof input === "string") {
+      const userMessage = { role: "user", content: input };
+      historyInputMessages_before_hf_transform.push(deepCopy(userMessage));
+      hfMessages.push(deepCopy(userMessage)); 
+    } else if (Array.isArray(input)) { // LanguageModelMessage[]
+      historyInputMessages_before_hf_transform.push(...deepCopy(input));
+      hfMessages.push(...deepCopy(input)); 
+    } else {
+      throw new Error("Invalid input type for promptStreaming. Must be string or array.");
+    }
+    
+    // At this point, `historyInputMessages_before_hf_transform` contains the messages
+    // as they should be for history update (original format).
+    // `hfMessages` contains the same for now, and will be transformed for multimodal if applicable.
+    // For Hugging Face, we'll assume text-only for now as per instructions,
+    // and will adjust after documentation check.
+
+    // 5. Multimodal Transformation (Placeholder - ASSUMING TEXT ONLY for now)
+    // This section will be revised after checking Hugging Face documentation.
+    // For now, ensure content is string and warn/discard image parts.
+    const processedHfMessages = await Promise.all(
+        hfMessages.map(async (msg) => {
+            if (Array.isArray(msg.content)) {
+                let textContent = "";
+                let hasNonText = false;
+                for (const part of msg.content) {
+                    if (part.type === "text") {
+                        textContent += (textContent ? "\n" : "") + part.value;
+                    } else {
+                        hasNonText = true;
+                        console.warn(`Hugging Face Chat Completions: Non-text part of type '${part.type}' found and will be discarded. Multimodal support TBD.`);
+                    }
+                }
+                if (hasNonText && !textContent) {
+                   // If only non-text parts, this might be an issue.
+                   // For now, let it pass as an empty string or handle as an error.
+                   console.error("Hugging Face Chat Completions: Message content resulted in empty text after discarding non-text parts.");
+                   return { ...msg, content: "" }; // Or throw error
+                }
+                return { ...msg, content: textContent };
+            }
+            return msg; // Content is already a string or not an array
+        })
+    );
+    
+    const requestBody = {
+      messages: processedHfMessages,
+      temperature: options.temperature,
+      top_k: options.top_k,
+      max_tokens: options.max_tokens,
+      stream: true,
+    };
+    // Remove undefined options to avoid issues with the API
+    Object.keys(requestBody).forEach(key => requestBody[key] === undefined && delete requestBody[key]);
 
     const response = await fetch(
       `${this.config.endpoint}/models/${this.config.model}/v1/chat/completions`,
       {
         method: "POST",
         headers,
-        body: JSON.stringify({
-          messages,
-          ...options,
-          stream: true,
-        }),
+        body: JSON.stringify(requestBody),
       }
     );
 
     if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`HTTP error! status: ${response.status}, body: ${error}`);
+      const errorText = await response.text();
+      throw new Error(`HTTP error! status: ${response.status} ${response.statusText} - ${errorText}`);
     }
 
     const responseChunks = [];
-    const reader = response.body
-      .pipeThrough(new TextDecoderStream())
-      .getReader();
-
+    const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
     let buffer = "";
 
     try {
       while (true) {
         const { value, done } = await reader.read();
         if (done) {
-          this._addToHistory(prompt, responseChunks.join(""));
+          const assistantResponseText = responseChunks.join("");
+          // History Update
+          if (typeof input === "string") {
+             // Original input was a string, use it directly for _addToHistory
+            this._addToHistory(input, assistantResponseText);
+          } else if (Array.isArray(input)) {
+            // Original input was an array.
+            // `historyInputMessages_before_hf_transform` contains the full context before assistant's reply.
+            this._setConversationHistory([
+              ...historyInputMessages_before_hf_transform,
+              { role: "assistant", content: assistantResponseText },
+            ]);
+          }
           break;
         }
 
         buffer += value;
         const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
+        buffer = lines.pop() || ""; 
 
         for (const line of lines) {
           if (line.trim() === "") continue;
           if (line.startsWith("data: ")) {
-            const data = line.slice(6);
-            if (data === "[DONE]") {
-              this._addToHistory(prompt, responseChunks.join(""));
-              return;
+            const dataStr = line.slice(6);
+            if (dataStr === "[DONE]") {
+              // This part is reached if [DONE] is not the last part of the stream / buffer.
+              // The main history update is in the `if (done)` block.
+              // However, if the stream ends exactly with `data: [DONE]\n\n`, this might be triggered first.
+              // To avoid double history update, we ensure the primary one is after the loop.
+              // If for some reason the loop doesn't break on `done` but receives `[DONE]` here,
+              // we can also update and return.
+              if (responseChunks.length > 0) { // Only update if we have some content.
+                const assistantResponseText = responseChunks.join("");
+                 if (typeof input === "string") {
+                    this._addToHistory(input, assistantResponseText);
+                  } else if (Array.isArray(input)) {
+                    this._setConversationHistory([
+                      ...historyInputMessages_before_hf_transform,
+                      { role: "assistant", content: assistantResponseText },
+                    ]);
+                  }
+              }
+              return; 
             }
             try {
-              const parsed = JSON.parse(data);
+              const parsed = JSON.parse(dataStr);
               if (parsed?.choices?.[0]?.delta?.content) {
                 const content = parsed.choices[0].delta.content;
                 responseChunks.push(content);
                 yield content;
               }
             } catch (e) {
-              console.error("Error parsing SSE data:", e);
+              console.error("Error parsing SSE data for Hugging Face:", dataStr, e);
             }
           }
         }

--- a/openai/Session.mjs
+++ b/openai/Session.mjs
@@ -1,133 +1,215 @@
 import SharedSession from "../shared/Session.mjs";
 
+// Helper function to convert Blob to Data URI
+async function blobToDataURI(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
+
+// Helper function to convert ArrayBuffer to Data URI
+async function arrayBufferToDataURI(buffer, mimeType = "image/jpeg") { // Default mimeType
+  const blob = new Blob([buffer], { type: mimeType });
+  return blobToDataURI(blob);
+}
+
+// Helper function to convert plain base64 string to Data URI
+function base64ToDataURI(base64String, mimeType = "image/jpeg") {
+  return `data:${mimeType};base64,${base64String}`;
+}
+
+
 class Session extends SharedSession {
-  async prompt(prompt, options = {}) {
-    const headers = {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${this.config.credentials?.apiKey || ""}`,
-      Accept: "application/json",
-    };
-    options.temperature =
-      options.temperature ??
-      this.ai.languageModel._capabilities.defaultTemperature;
-
-    const messages = [
-      ...(this.options.systemPrompt
-        ? [{ role: "system", content: this.options.systemPrompt }]
-        : []),
-      ...(this.options.initialPrompts || []),
-      ...this._getConversationHistory(),
-      { role: "user", content: prompt },
-    ];
-
-    const response = await fetch(
-      `${this.config.endpoint}/v1/chat/completions`,
-      {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          model: this.config.model,
-          messages,
-          ...options,
-        }),
-      }
-    );
-    if (!response.ok) {
-      const error = await response.text();
-      console.error("Error body:", error);
-      throw new Error(`HTTP error! status: ${response.status}, body: ${error}`);
+  async prompt(input, options = {}) {
+    // Utilizes promptStreaming to make the API call and handle history
+    const output = [];
+    for await (const message of this.promptStreaming(input, options)) {
+      output.push(message);
     }
-    try {
-      const data = await response.json();
-      const assistantResponse = data.choices[0].message.content;
-      this._addToHistory(prompt, assistantResponse);
-      return assistantResponse;
-    } catch (error) {
-      throw error;
-    }
+    // History update is handled within promptStreaming
+    return output.join("");
   }
 
-  async *promptStreaming(prompt, options = {}) {
+  async *promptStreaming(input, options = {}) {
     const headers = {
       "Content-Type": "application/json",
       Authorization: `Bearer ${this.config.credentials?.apiKey || ""}`,
-      Accept: "text/event-stream",
+      Accept: "text/event-stream", // Changed for streaming
     };
     options.temperature =
       options.temperature ??
       this.ai.languageModel._capabilities.defaultTemperature;
 
-    const messages = [
-      ...(this.options.systemPrompt
-        ? [{ role: "system", content: this.options.systemPrompt }]
-        : []),
-      ...(this.options.initialPrompts || []),
-      ...this._getConversationHistory(),
-      { role: "user", content: prompt },
-    ];
+    // This variable will store messages in the LanguageModelMessage format for history updates.
+    let historyInputMessages_before_openai_transform = [];
+    // This variable will store messages transformed for the OpenAI API.
+    let openAIMessagesForAPI = [];
+
+    // 1. System Prompt
+    let systemContent = "";
+    if (this.options.systemPrompt) {
+      systemContent = this.options.systemPrompt;
+    }
+    // Concatenate any system messages from initialPrompts
+    (this.options.initialPrompts || []).forEach(msg => {
+      if (msg.role === "system") {
+        if (systemContent) systemContent += "\n"; // Add newline if appending
+        systemContent += msg.content;
+      }
+    });
+    if (systemContent) {
+      openAIMessagesForAPI.push({ role: "system", content: systemContent });
+      // System messages are generally not part of `historyInputMessages_before_openai_transform`
+      // as they are implicitly part of the session's configuration.
+    }
+
+    // 2. User/Assistant/Tool Prompts from initialPrompts (non-system)
+    (this.options.initialPrompts || []).forEach(msg => {
+      if (msg.role !== "system") {
+        historyInputMessages_before_openai_transform.push(msg);
+        openAIMessagesForAPI.push(JSON.parse(JSON.stringify(msg))); // Deep copy for transformation
+      }
+    });
+    
+    // 3. Conversation History
+    const conversationHistory = this._getConversationHistory();
+    historyInputMessages_before_openai_transform.push(...conversationHistory);
+    openAIMessagesForAPI.push(...conversationHistory.map(m => JSON.parse(JSON.stringify(m)))); // Deep copy
+
+    // 4. Current Input
+    if (typeof input === "string") {
+      const userMessage = { role: "user", content: input };
+      historyInputMessages_before_openai_transform.push(userMessage);
+      openAIMessagesForAPI.push(JSON.parse(JSON.stringify(userMessage))); // Deep copy
+    } else if (Array.isArray(input)) { // LanguageModelMessage[]
+      historyInputMessages_before_openai_transform.push(...input);
+      openAIMessagesForAPI.push(...input.map(m => JSON.parse(JSON.stringify(m)))); // Deep copy
+    } else {
+      throw new Error("Invalid input type for promptStreaming. Must be string or array.");
+    }
+
+    // 5. Transform openAIMessagesForAPI Content for Multimodal
+    const processedOpenAIMessages = await Promise.all(
+      openAIMessagesForAPI.map(async (msg) => {
+        // Only transform user messages, and only if content is array or model is vision-capable
+        // Forcing transformation if content is already an array (LanguageModelMessageContent[])
+        // or checking if the model is a known vision model.
+        const isVisionModel = this.config.model && (this.config.model.includes("vision") || this.config.model.includes("gpt-4-turbo"));
+
+        if (msg.role === "user" && (Array.isArray(msg.content) || isVisionModel)) {
+          let parts = [];
+          if (typeof msg.content === 'string') {
+            // If it's a string but for a vision model, wrap it as a text part.
+            parts.push({ type: "text", text: msg.content });
+          } else if (Array.isArray(msg.content)) { // LanguageModelMessageContent[]
+            for (const part of msg.content) {
+              if (part.type === "text") {
+                parts.push({ type: "text", text: part.value });
+              } else if (part.type === "image") {
+                let imageUrl;
+                if (typeof part.value === 'string') {
+                  if (part.value.startsWith('data:')) {
+                    imageUrl = part.value;
+                  } else { // Assume plain base64
+                    imageUrl = base64ToDataURI(part.value, part.mimeType || 'image/jpeg');
+                  }
+                } else if (part.value instanceof Blob) {
+                  imageUrl = await blobToDataURI(part.value);
+                } else if (part.value instanceof ArrayBuffer) {
+                  imageUrl = await arrayBufferToDataURI(part.value, part.mimeType || 'image/jpeg');
+                } else {
+                  console.warn("Unsupported image content value type:", typeof part.value, "for OpenAI. Skipping part.");
+                  continue; 
+                }
+                parts.push({ type: "image_url", image_url: { url: imageUrl, detail: "auto" } });
+              }
+            }
+          }
+          // If parts is empty (e.g. only unsupported image types), and original content was a string, keep original string.
+          // Otherwise, OpenAI API might error on empty content array for user message.
+          if (parts.length === 0 && typeof msg.content === 'string') {
+             return { ...msg, content: msg.content }; // Keep original string content
+          }
+          return { ...msg, content: parts };
+        }
+        return msg; // Return as is if not a user message needing multimodal transform or not a vision model
+      })
+    );
+    
+    const requestBody = {
+      model: this.config.model,
+      messages: processedOpenAIMessages,
+      temperature: options.temperature, // Ensure temperature is passed
+      // any other options from `options` should be spread if they are valid OpenAI params
+      ...(options.maxTokens && {max_tokens: options.maxTokens}), // Example: mapping maxTokens
+      stream: true,
+    };
+    // Remove undefined options to avoid issues with OpenAI API
+    Object.keys(requestBody).forEach(key => requestBody[key] === undefined && delete requestBody[key]);
+
 
     const response = await fetch(
       `${this.config.endpoint}/v1/chat/completions`,
       {
         method: "POST",
         headers,
-        body: JSON.stringify({
-          model: this.config.model,
-          messages,
-          ...options,
-          stream: true,
-        }),
+        body: JSON.stringify(requestBody),
       }
     );
 
     if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`HTTP error! status: ${response.status}, body: ${error}`);
+      const errorText = await response.text();
+      throw new Error(`HTTP error! status: ${response.status} ${response.statusText} - ${errorText}`);
     }
 
     const responseChunks = [];
-
-    const reader = response.body
-      .pipeThrough(new TextDecoderStream())
-      .getReader();
-
+    const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
     let buffer = "";
 
     try {
       while (true) {
         const { value, done } = await reader.read();
         if (done) {
-          // Update conversation history with complete response
-          this._addToHistory(prompt, responseChunks.join(""));
+          const assistantResponseText = responseChunks.join("");
+          // History Update
+          if (typeof input === "string") {
+            // For string input, _addToHistory takes the original string prompt
+            this._addToHistory(input, assistantResponseText);
+          } else if (Array.isArray(input)) {
+            // For array input, _setConversationHistory takes the full history before this turn + this turn's input + assistant response
+            // historyInputMessages_before_openai_transform correctly represents this.
+            this._setConversationHistory([
+              ...historyInputMessages_before_openai_transform,
+              { role: "assistant", content: assistantResponseText },
+            ]);
+          }
           break;
         }
 
         buffer += value;
         const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
+        buffer = lines.pop() || ""; 
 
         for (const line of lines) {
           const trimmedLine = line.trim();
-          if (!trimmedLine || trimmedLine === "data: [DONE]") continue;
-
+          if (trimmedLine === "" || trimmedLine === "data: [DONE]") {
+            continue;
+          }
           if (trimmedLine.startsWith("data: ")) {
+            const jsonStr = trimmedLine.substring(6);
             try {
-              const jsonStr = trimmedLine.slice(6);
               const data = JSON.parse(jsonStr);
-              if (data.choices?.[0]?.delta?.content) {
+              if (data.choices && data.choices[0] && data.choices[0].delta && data.choices[0].delta.content) {
                 const content = data.choices[0].delta.content;
                 responseChunks.push(content);
                 yield content;
-              } else if (data.choices?.[0]?.message?.content) {
-                const content = data.choices[0].message.content;
-                responseChunks.push(content);
-                yield content;
               }
-            } catch (error) {
-              console.error("Parse error:", error);
+            } catch (e) {
+              console.error("Failed to parse JSON stream chunk for OpenAI:", jsonStr, e);
             }
-          } else {
-            console.warn("Unexpected line format:", trimmedLine);
           }
         }
       }


### PR DESCRIPTION
This commit adapts the 'prompt' and 'promptStreaming' APIs for all Sessions (shared, Anthropic, Gemini, OpenAI, HuggingFace) to conform to the new Prompt API specification, enabling multimodal inputs.

Key changes include:
- Modified `prompt` and `promptStreaming` signatures to accept `LanguageModelPrompt` (string or array of messages).
- Updated provider-specific session implementations to handle multimodal content:
    - Anthropic: Images (Blob, ArrayBuffer, base64) converted to base64 for the Messages API.
    - Gemini: Images converted to `inlineData` (base64) for the `contents` array. System prompts handled via `systemInstruction`.
    - OpenAI: Images converted to `image_url` (data URI) for the `messages` array.
    - HuggingFace: Falls back to text-only for array inputs, concatenating text parts and warning for non-text parts, due to unclear multimodal support on its generic chat completions endpoint.
- Refactored provider `prompt` methods to use their respective `promptStreaming` methods for consistency.
- Updated conversation history management (`_addToHistory`, `_setConversationHistory` in `shared/Session.mjs`) to correctly handle string and array inputs, ensuring accurate context for subsequent calls.
- `shared/Session.mjs#_countTokensInMessages` updated to account for array-based content and provide placeholder counts for non-text parts.
- `shared/Session.mjs#chat` method updated to align with new prompt signatures and token counting.
- Added comprehensive unit tests for shared and provider-specific sessions, covering various input types, multimodal handling, history management, and error scenarios using a mocked `fetch`.