### PR TITLE
Add AbortSignal support to streaming methods

### DIFF
--- a/packages/ai.matey.core/src/bridge.ts
+++ b/packages/ai.matey.core/src/bridge.ts
@@ -268,6 +268,10 @@ export class Bridge<
       // Step 8: Yield chunks to caller
       let chunkSequence = 0;
       for await (const chunk of frontendStream) {
+        // Check AbortSignal before yielding each chunk
+        if (options?.signal?.aborted) {
+          break;
+        }
         chunkSequence++;
         yield chunk as InferFrontendStreamChunk<TFrontend>;
       }

--- a/packages/ai.matey.core/src/router.ts
+++ b/packages/ai.matey.core/src/router.ts
@@ -633,6 +633,10 @@ export class Router implements IRouter {
       const stream = this.executeStreamOnBackend(primaryBackend, translatedRequest, signal);
 
       for await (const chunk of stream) {
+        // Check AbortSignal before yielding each chunk
+        if (signal?.aborted) {
+          break;
+        }
         yield chunk;
       }
 

--- a/packages/wrapper/src/chat.ts
+++ b/packages/wrapper/src/chat.ts
@@ -299,6 +299,11 @@ export class Chat {
       let sequence = 0;
 
       for await (const chunk of stream) {
+        // Check AbortSignal before processing each chunk
+        if (options?.signal?.aborted) {
+          break;
+        }
+
         if (chunk.type === 'content') {
           accumulated += chunk.delta;
           sequence = chunk.sequence;
@@ -461,6 +466,11 @@ export class Chat {
       const stream = this.backend.executeStream(request, options?.signal);
 
       for await (const chunk of stream) {
+        // Check AbortSignal before processing each chunk
+        if (options?.signal?.aborted) {
+          break;
+        }
+
         switch (chunk.type) {
           case 'content': {
             accumulated += chunk.delta;

--- a/tests/unit/abort-signal-streaming.test.ts
+++ b/tests/unit/abort-signal-streaming.test.ts
@@ -1,0 +1,256 @@
+/**
+ * AbortSignal Streaming Tests
+ *
+ * Tests that AbortSignal is properly checked inside streaming loops
+ * in Bridge, Router, and Chat (wrapper) classes.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Bridge } from 'ai.matey.core';
+import type {
+  FrontendAdapter,
+  BackendAdapter,
+  IRChatRequest,
+  IRChatResponse,
+  IRStreamChunk,
+} from 'ai.matey.types';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createMockFrontend(): FrontendAdapter {
+  return {
+    metadata: {
+      name: 'mock-frontend',
+      version: '1.0.0',
+      provider: 'Mock',
+      capabilities: {
+        streaming: true,
+        multiModal: false,
+        tools: false,
+        systemMessageStrategy: 'in-messages',
+        supportsMultipleSystemMessages: true,
+      },
+    },
+    toIR: vi.fn((request: any) => ({
+      messages: request.messages || [],
+      metadata: {
+        requestId: 'test-req-id',
+        timestamp: Date.now(),
+        provenance: {},
+      },
+    })),
+    fromIR: vi.fn((response: IRChatResponse) => ({
+      id: response.metadata.requestId,
+      content: response.message.content,
+    })),
+    fromIRStream: vi.fn(async function* (stream) {
+      for await (const chunk of stream) {
+        yield chunk;
+      }
+    }),
+  } as unknown as FrontendAdapter;
+}
+
+/**
+ * Create a mock backend that yields many chunks with a controllable delay.
+ * This allows us to abort mid-stream.
+ */
+function createSlowMockBackend(chunkCount: number = 10): BackendAdapter {
+  return {
+    metadata: {
+      name: 'mock-backend',
+      version: '1.0.0',
+      provider: 'Mock',
+      capabilities: {
+        streaming: true,
+        multiModal: false,
+        tools: false,
+        systemMessageStrategy: 'in-messages',
+        supportsMultipleSystemMessages: true,
+      },
+    },
+    fromIR: vi.fn((request) => request),
+    toIR: vi.fn((response) => response),
+    execute: vi.fn(async (request: IRChatRequest) => {
+      return {
+        message: { role: 'assistant', content: 'Hello!' },
+        finishReason: 'stop',
+        metadata: {
+          requestId: request.metadata.requestId,
+          provenance: { backend: 'mock-backend' },
+        },
+      } as IRChatResponse;
+    }),
+    executeStream: vi.fn(async function* () {
+      yield { type: 'start', sequence: 0 } as IRStreamChunk;
+      for (let i = 1; i <= chunkCount; i++) {
+        yield {
+          type: 'content',
+          sequence: i,
+          delta: `chunk${i} `,
+          role: 'assistant',
+        } as IRStreamChunk;
+      }
+      yield {
+        type: 'done',
+        sequence: chunkCount + 1,
+        finishReason: 'stop',
+        message: { role: 'assistant', content: 'complete' },
+      } as IRStreamChunk;
+    }),
+  } as unknown as BackendAdapter;
+}
+
+// ============================================================================
+// Bridge.chatStream AbortSignal Tests
+// ============================================================================
+
+describe('Bridge.chatStream AbortSignal support', () => {
+  it('should stop yielding chunks when signal is aborted mid-stream', async () => {
+    const frontend = createMockFrontend();
+    const backend = createSlowMockBackend(20);
+    const bridge = new Bridge(frontend, backend);
+
+    const controller = new AbortController();
+    const chunks: any[] = [];
+
+    const stream = bridge.chatStream(
+      { messages: [{ role: 'user', content: 'Hello' }] } as any,
+      { signal: controller.signal }
+    );
+
+    let count = 0;
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+      count++;
+      // Abort after receiving 3 chunks
+      if (count >= 3) {
+        controller.abort();
+      }
+    }
+
+    // Should have stopped early -- not all 22 chunks (start + 20 content + done)
+    expect(chunks.length).toBeLessThan(22);
+    // Should have at least the 3 we consumed before aborting
+    expect(chunks.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('should not yield any chunks when signal is already aborted', async () => {
+    const frontend = createMockFrontend();
+    const backend = createSlowMockBackend(10);
+    const bridge = new Bridge(frontend, backend);
+
+    const controller = new AbortController();
+    controller.abort(); // Pre-abort
+
+    const chunks: any[] = [];
+    const stream = bridge.chatStream(
+      { messages: [{ role: 'user', content: 'Hello' }] } as any,
+      { signal: controller.signal }
+    );
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    // Should yield zero chunks since signal was already aborted
+    expect(chunks.length).toBe(0);
+  });
+
+  it('should yield all chunks when no signal is provided', async () => {
+    const frontend = createMockFrontend();
+    const backend = createSlowMockBackend(5);
+    const bridge = new Bridge(frontend, backend);
+
+    const chunks: any[] = [];
+    const stream = bridge.chatStream(
+      { messages: [{ role: 'user', content: 'Hello' }] } as any,
+    );
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    // Should receive all chunks: start + 5 content + done = 7
+    expect(chunks.length).toBe(7);
+  });
+
+  it('should yield all chunks when signal is never aborted', async () => {
+    const frontend = createMockFrontend();
+    const backend = createSlowMockBackend(5);
+    const bridge = new Bridge(frontend, backend);
+
+    const controller = new AbortController();
+    const chunks: any[] = [];
+    const stream = bridge.chatStream(
+      { messages: [{ role: 'user', content: 'Hello' }] } as any,
+      { signal: controller.signal }
+    );
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    // Should receive all chunks: start + 5 content + done = 7
+    expect(chunks.length).toBe(7);
+  });
+});
+
+// ============================================================================
+// Wrapper Chat.stream AbortSignal Tests
+// ============================================================================
+
+describe('Chat.stream (wrapper) AbortSignal support', () => {
+  it('should stop streaming when signal is aborted mid-stream', async () => {
+    const { Chat } = await import('ai.matey.wrapper');
+
+    const mockBackend = {
+      execute: vi.fn(async () => ({
+        message: { role: 'assistant', content: 'Hello' },
+        finishReason: 'stop',
+        metadata: { requestId: 'req_1', provenance: {} },
+      })),
+      executeStream: vi.fn(async function* () {
+        for (let i = 0; i < 20; i++) {
+          yield {
+            type: 'content' as const,
+            sequence: i,
+            delta: `word${i} `,
+            role: 'assistant' as const,
+          };
+        }
+        yield {
+          type: 'done' as const,
+          sequence: 20,
+          finishReason: 'stop' as const,
+          message: { role: 'assistant' as const, content: 'complete' },
+        };
+      }),
+    };
+
+    const chat = new Chat({
+      backend: mockBackend,
+    });
+
+    const controller = new AbortController();
+    const chunks: any[] = [];
+
+    const stream = chat.stream('Hello', { signal: controller.signal });
+
+    // stream() returns AsyncGenerator when no callbacks
+    let count = 0;
+    for await (const chunk of stream as AsyncGenerator<any>) {
+      chunks.push(chunk);
+      count++;
+      if (count >= 3) {
+        controller.abort();
+      }
+    }
+
+    // Should have stopped before receiving all 20 content chunks
+    expect(chunks.length).toBeLessThan(20);
+    expect(chunks.length).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Summary

- Check `signal.aborted` inside the `for await` loops in `Bridge.chatStream()`, `Router.executeStream()`, and `Chat.stream()`/`streamWithCallbacks()` so consumers no longer need to manually break out of streams after aborting
- The `signal` parameter was already accepted and forwarded to backends/middleware, but the yield loops themselves never inspected it, causing streams to keep running after the caller aborted
- Adds 5 unit tests covering mid-stream abort, pre-aborted signal, and normal (non-aborted) operation

## Motivation

Consumers like the clawser project currently have to add their own `if (options.signal?.aborted) break;` after each chunk when iterating over a `chatStream()`. This is error-prone and easy to forget. Since `RequestOptions` already declares `signal?: AbortSignal`, the streaming loops should respect it natively.

## Changed files

| File | Change |
|------|--------|
| `packages/ai.matey.core/src/bridge.ts` | Check `signal.aborted` in `chatStream()` loop before yielding |
| `packages/ai.matey.core/src/router.ts` | Check `signal.aborted` in `executeStream()` loop before yielding |
| `packages/wrapper/src/chat.ts` | Check `signal.aborted` in both `streamAsGenerator()` and `executeStreamWithToolLoop()` loops |
| `tests/unit/abort-signal-streaming.test.ts` | New test file with 5 tests |

## Test plan

- [x] All 5 new AbortSignal tests pass
- [x] All 132 existing related tests pass (bridge-completeness, wrapper-ir, streaming, router)
- [ ] Manual verification: create an AbortController, call `bridge.chatStream()` with its signal, abort mid-stream, confirm iteration stops