### PR TITLE
Add LiteRT-LM on-device browser backend; ecosystem wave roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -413,284 +413,110 @@ Legend: ⭐⭐ = Excellent (best-in-class), ⭐ = Good (competitive), ⚠️ = L
 | Middleware pipeline | ⭐⭐⭐⭐⭐ | ⭐⭐ |
 | Self-hosted | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ |
 
-## Development Priorities
+## Development Priorities — The Wave Plan (updated 2026-07)
 
-### Production Validation ✅
+Grounded in a July-2026 competitive analysis (Vercel AI SDK 7, LangChain/LangGraph 1.0, Mastra
+1.0, OpenAI Agents SDK, VoltAgent, LiteLLM/Portkey/Helicone gateways). Positioning decision:
+**ai.matey remains a pure self-hosted library** — gateway-style capabilities ship as
+self-hostable primitives, never a managed service.
 
-**Status**: All core packages production-ready (December 2025)
+Ranked capability gaps this plan closes: (1) MCP client+server — the defining 2026 shift,
+table stakes; (2) reusable Agent abstraction; (3) durable execution/checkpointing; (4) agent
+memory; (5) evals; (6) human-in-the-loop tool approvals; (7) speech/realtime-voice/image-gen/
+reranking; (8) RAG + vector connectors; (9) content guardrails; (10) observability UI + live
+pricing sync.
 
-**Comprehensive Testing Complete**:
-- ✅ **14 integration test applications** created and validated
-- ✅ **50+ test scenarios** executed successfully
-- ✅ **100% pass rate** on all core packages
-- ✅ **95%+ overall success rate** across entire ecosystem
-- ✅ **8 integration patterns** discovered and documented
-- ✅ **Performance benchmarks** established for all critical paths
+### ✅ Wave 0 (shipped 2026-07): LiteRT-LM on-device backend
 
-**Key Achievements**:
-- ✅ Middleware overhead: 1-9ms (6-layer chain, <10ms target met)
-- ✅ WebSocket latency: 101ms (exceeded <150ms target)
-- ✅ Batch throughput: 14.87 req/s (met 15+ req/s target)
-- ✅ Cache speedup: 1000x+ (exceeded 100x target)
-- ✅ Cost savings: 84% (exceeded 80% target)
+`LiteRtLmBackendAdapter` in `ai.matey.backend.browser` — Gemma on WebGPU via `@litert-lm/core`
+(optional peer), engine caching per model URL, streaming, semantic-drift warnings for the Web
+SDK's dropped features. (`@litertjs/core` is tensor-only and deliberately out of scope; the
+MediaPipe genai API is maintenance-mode.)
 
-**Documentation Created**:
-- 📘 [Integration Patterns Guide](./PATTERNS.md) - 8 production-ready patterns with examples
-- 📊 [Performance Benchmarks](./BENCHMARKS.md) - Comprehensive performance data
-- 🧪 [Testing Guide](./TESTING.md) - Test coverage and methodology
+### Wave 1 (next): MCP + Agents
 
-**See Also**:
-- [Test Report](https://github.com/johnhenry/ai.matey.examples/blob/main/FINAL-COMPREHENSIVE-TEST-REPORT.md) - Full validation results
-- [Examples Repository](https://github.com/johnhenry/ai.matey.examples) - All test applications
+**MCP client + server — new package `ai.matey.mcp`** (`packages/mcp`; optional peer
+`@modelcontextprotocol/sdk`):
+- Client: `createMCPToolSet({ transport: stdio | streamableHttp, oauth?, namePrefix?, include? })`
+  → `{ tools: Record<string, ToolDefinition>, listResources/readResource, listPrompts/getPrompt
+  (→ IRMessage[]), refreshTools, close }`. MCP tool `inputSchema` passes straight through to
+  `IRTool.parameters` (both raw JSON Schema); `tools/call` isError results throw so the existing
+  runTools loop feeds them back as error tool results. Tools plug into `bridge.runTools`/Agent
+  with zero loop changes.
+- Server: `createMCPServer({ name, tools, bridge? })` on the SDK's **low-level Server**
+  (`setRequestHandler` with raw JSON Schema — avoids a zod dependency), reusing
+  `validateToolArgs`; `connectStdio()` plus Streamable HTTP `nodeHandler()`/`genericHandler()`
+  for the http adapters. v1 scope: tools only (server-side resources/prompts in v2).
+- Tests: SDK `InMemoryTransport.createLinkedPair()` roundtrips; peer-missing → friendly
+  `AdapterError(UNSUPPORTED_FEATURE)`.
 
----
+**Agent abstraction — new package `ai.matey.agent`** (`packages/agent`):
+- Small core prerequisite: `RunToolsOptions.stopWhen?: (step) => boolean | Promise<boolean>`
+  checked after each iteration in `run-tools.ts`.
+- `Agent` class over `createRunTools`: `{ bridge | backend+model, name, instructions
+  (string | (ctx) => string), tools, memory?, maxIterations, stopWhen, approvals?, parameters }`;
+  `run()`, `stream()` (v1: per-step events via onStepFinish queue), `asTool()` for multi-agent
+  handoffs (agent-as-tool with mapInput/mapResult).
+- Typed run context: tools are `AgentToolDefinition<TContext>` — wrapped at run time so
+  `execute(input, ctx)` receives `ctx.context`.
+- Human-in-the-loop: per-tool `needsApproval: boolean | (input, ctx) => boolean`; suspension is
+  simply an unresolved promise awaiting the `ApprovalHandler` (AbortSignal still cancels);
+  `createApprovalQueue()` gives UIs pending()/approve()/deny(); denial throws
+  `TOOL_APPROVAL_DENIED` → converted to an isError tool result so the model adapts.
+- v2 (types reserved now): `AgentCheckpoint` + `onSuspend`/`resume(checkpoint, decisions)` for
+  durable runs; pluggable checkpoint stores.
 
-### Code Quality Improvements
+### Wave 2: Memory + Guardrails
 
-#### Re-enable Suppressed TypeScript ESLint Rules
+**Memory — new package `ai.matey.memory`** (`packages/memory`; depends on types/errors/utils
+only via a structural `EmbeddingProvider = { embed() }`):
+- `createConversationMemory({ store?, maxMessages?, compressor? })` — session history with
+  windowing and optional LLM compression of old turns into a summary message.
+- `createSemanticMemory({ embedder /* the Bridge */, store?, recallLimit?, minScore?, extract?,
+  inject? })` — recall via existing `bridge.embed()` + `cosineSimilarity`; `VectorStore`
+  interface with in-memory brute-force v1, pgvector/qdrant optional-peer subpaths v2.
+- Both implement the `AgentMemory` beforeRun/afterRun contract consumed by Agent;
+  `composeMemory(...)` chains them. Embedding caching comes free by stacking the existing
+  `createEmbeddingCachingMiddleware`.
 
-**Context**: During the monorepo migration, several strict TypeScript ESLint rules were temporarily disabled to allow the migration to complete without blocking on type safety issues. These suppressions are documented in `eslint.config.js` (lines 65-75) with a TODO comment indicating they should be re-enabled in follow-up work.
+**Guardrails — extend `ai.matey.middleware`** (new ErrorCode `GUARDRAIL_VIOLATION`):
+- `createPIIRedactionMiddleware` — deterministic regex builtins (email/phone/ssn/creditCard/
+  ipAddress/iban/apiKey) + custom patterns; actions transform (default) / deny / log; input,
+  output, or both directions.
+- `createModerationMiddleware` — LLM judge via a designated cheap bridge using the forced-tool-
+  call trick (schema-only, no zod); category scores + threshold; failOpen default.
+- `createAuditLogMiddleware` — hash-only by default (privacy-safe), drains violations recorded
+  in middleware `context.state`, one record per request with usage/duration/error.
+- Because `runTools`/Agent call `executeIR` through the middleware stack every iteration, rails
+  automatically police each turn — including tool results — with zero extra wiring.
 
-**Goal**: Systematically re-enable each suppressed rule and fix all violations to improve type safety across the codebase.
+### Wave 3: Modalities, RAG, Evals
 
-**Suppressed Rules** (9 total):
-1. `@typescript-eslint/no-unsafe-assignment` - Prevents assignments from `any` typed values
-2. `@typescript-eslint/no-unsafe-member-access` - Prevents accessing properties on `any` typed values
-3. `@typescript-eslint/no-unsafe-call` - Prevents calling functions with `any` typed values
-4. `@typescript-eslint/no-unsafe-return` - Prevents returning `any` typed values
-5. `@typescript-eslint/no-unsafe-argument` - Prevents passing `any` typed values as arguments
-6. `@typescript-eslint/no-explicit-any` - Prevents explicit use of `any` type
-7. `@typescript-eslint/prefer-nullish-coalescing` - Enforces nullish coalescing (`??`) over logical OR (`||`)
-8. `@typescript-eslint/require-await` - Requires `async` functions to contain `await` expressions
-9. `@typescript-eslint/no-redundant-type-constituents` - Prevents redundant types in union/intersection types
+- **Speech**: `generateSpeech` (TTS) + `transcribe` (STT) IR surfaces with OpenAI/ElevenLabs/
+  Deepgram adapters; realtime voice exploration after.
+- **Image generation** (`generateImage`) and **reranking** IR surfaces.
+- **RAG**: chunking + retrieval pipeline over Wave-2 vector stores (pgvector/Qdrant/Pinecone/
+  Chroma connectors as optional peers).
+- **Evals**: datasets + LLM-as-judge + rule-based metrics (relevance/faithfulness/toxicity),
+  running on ai.matey's own provider layer — the industry's evals gap (observability ~89% vs
+  evals ~52% adoption) is ai.matey's opening.
 
-**Approach**:
-1. Re-enable one rule at a time
-2. Run `npx turbo run lint --force` to bypass cache and see all violations
-3. Fix all violations for that rule across the monorepo
-4. Verify tests still pass with `npm test`
-5. Commit the changes
-6. Move to next rule
+### Wave 4: Reach & polish
 
-**Priority Order** (suggested):
-- Start with simpler rules like `require-await` and `no-redundant-type-constituents`
-- Then tackle `prefer-nullish-coalescing`
-- Finally address the stricter `any`-related rules which may require more significant refactoring
+- Additional browser backends beside LiteRT-LM: **web-llm/MLC** (OpenAI-shaped, fastest tok/s)
+  and **transformers.js v4** (ONNX/WebGPU; also a path to on-device embeddings).
+- **Vue and Svelte hooks** mirroring `ai.matey.react.core`.
+- **Devtools/trace inspector** over the existing OpenTelemetry + stats surfaces.
+- **Registry pricing auto-sync**: optional fetch of a maintained pricing feed at runtime
+  (`registerModels()` already supports live updates).
 
-**Reference**: See `eslint.config.js` lines 65-75 for current suppressions.
+### Durable strengths to preserve
 
-**Related Work**:
-- Several type assertion issues were already fixed in commits 5b667eb and 226fcc2
-- The `@typescript-eslint/no-unnecessary-type-assertion` rule was successfully re-enabled
+Zero runtime dependencies; 28 backends with 7 routing strategies, circuit breaker, fallback and
+parallel dispatch; 6 HTTP framework adapters with health/metrics/embeddings endpoints; the
+format-conversion CLI and OpenAI/Anthropic SDK shims; multi-format frontend adapters (few
+competitors can speak Anthropic's or Gemini's wire format into the same core).
 
----
-
-### Next Phase: Enhanced Documentation & Features
-
-**1. ✅ Structured Output with Zod** (COMPLETED - closes gap with Instructor-JS & Vercel AI)
-- ✅ Zod schema integration
-- ✅ Schema → tool definitions converter
-- ✅ Runtime validation
-- ✅ Type inference from schemas
-- ✅ Streaming with partial objects (`streamObject()`)
-- ✅ `generateObject()` method
-- ✅ Security utilities (PII detection, prompt injection detection)
-- 📦 **Implementation**: `packages/ai.matey.utils/src/structured-output.ts`
-- 📦 **Bridge integration**: `bridge.generateObject()` and `bridge.streamObject()` methods
-- ✅ **Tests**: 12 passing tests in `tests/unit/structured-output.test.ts`
-- 🎯 **Zero-dependency**: Zod is an **optional peer dependency** - only required if you use structured output features
-- 💡 **Installation**: Users only install `zod` if they need `generateObject()` or `streamObject()`
-
-**2. ✅ Integration Patterns as Reusable Components** (COMPLETED 2026-07 — `ai.matey.patterns`)
-- **Status**: ✅ 8 patterns validated and documented in [PATTERNS.md](./PATTERNS.md)
-- **Goal**: Extract patterns into reusable, importable utilities
-- **Deliverables**:
-  - Create `ai.matey.patterns` package with utilities:
-    - `createComplexityRouter()` - Intelligent query routing
-    - `createParallelAggregator()` - Multi-provider execution
-    - `createFailoverMiddleware()` - Automatic resilience
-    - `createCostOptimizer()` - Dynamic cost optimization
-    - `createBatchProcessor()` - Rate-limited batch processing
-  - Add `ai.matey.http/websocket` subpath for WebSocket streaming
-  - Integrate health monitoring with OpenTelemetry
-
-**3. Enhanced Documentation**
-- ✅ Integration patterns guide ([PATTERNS.md](./PATTERNS.md))
-- ✅ Performance benchmarks ([BENCHMARKS.md](./BENCHMARKS.md))
-- ✅ Testing guide ([TESTING.md](./TESTING.md))
-- Interactive code playground (web-based)
-- Video tutorials and walkthroughs
-- Step-by-step guides for common patterns
-- More real-world examples
-- API reference improvements
-
-**4. Circuit Breaker Enhancement** (Q2 2026) (⭐ → ⭐⭐)
-- **OpenTelemetry integration**: Emit circuit state changes as spans/events
-  - `circuit.opened`, `circuit.half_open`, `circuit.closed` events
-  - Failure count, threshold, and timeout as span attributes
-  - Integrates with existing OpenTelemetry middleware
-- Configurable failure thresholds per provider
-- Half-open state with graduated recovery
-- Circuit breaker events and webhooks for custom monitoring
-- Per-model circuit breakers (not just per-provider)
-- Health check improvements with circuit status
-
-**5. ✅ HTTP Server Improvements** (LARGELY COMPLETED 2026-07 — WebSocket subpath, /metrics, /health endpoints, per-route rate limits; compression still open)
-- **WebSocket support** for real-time streaming ✅ **Validated** (15/15 tests passing, 101ms latency)
-- Server-Sent Events (SSE) improvements
-- Better error handling and status codes
-- Request/response compression
-- Rate limiting per route/user
-- **Metrics endpoints**:
-  - Prometheus format metrics (`/metrics`)
-  - OpenTelemetry metrics export (integrates with existing OTel middleware)
-  - Circuit breaker status included
-- Health check endpoints with detailed status (`/health`, `/health/ready`, `/health/live`)
-
-**6. ✅ Embeddings Support** (COMPLETED 2026-07)
-- Embedding generation across providers (24 backends)
-- Batch embedding support with automatic chunking
-- Vector dimension normalization across providers
-- **Cost tracking integration**: Uses existing cost-tracking middleware
-- **Caching integration**: Cache embeddings using existing caching middleware
-- **Router integration**: Route embedding requests like chat (cost/latency optimized)
-
-### Future Phase: Semantic Caching & Guardrails
-
-**Semantic Caching** (unique differentiator)
-- **Middleware architecture**: Implemented as middleware, works with existing pipeline
-- Cache by semantic meaning, not exact match
-- Cosine similarity matching with configurable threshold
-- **Embeddings integration**: Uses Embeddings Support for semantic comparison
-- Cache across different provider formats (provider-agnostic)
-- **OpenTelemetry metrics**: Cache hit/miss rates, similarity scores
-- Performance: 20x faster than API calls
-
-**Guardrails System** (inspired by Portkey)
-- **Middleware architecture**: Implemented as middleware, composable with others
-- **Pre-built deterministic checks**: PII detection, profanity filtering, code detection, URL detection, prompt injection
-- **LLM-based checks**: Toxicity, bias, factual consistency (uses existing providers)
-- **Configurable actions**:
-  - `deny` - Block request and return error
-  - `log` - Log violation, continue request (uses existing logging middleware)
-  - `fallback` - Use fallback provider (uses existing router)
-  - `retry` - Retry with modifications (uses existing retry middleware)
-- **OpenTelemetry integration**: Guardrail violations tracked as events
-- Custom guardrail support via plugin API
-
-**OpenTelemetry Enhancement**
-- Additional integration examples (Jaeger, Zipkin, Datadog, Honeycomb)
-- Performance optimization for trace spans
-
-## Long-Term Vision
-
-### Enhanced Multi-Modal
-- **Audio processing**: Speech-to-text, text-to-speech across providers
-  - Uses existing router for provider selection
-  - Cost tracking integration
-- **Image generation**: DALL-E, Stable Diffusion, Midjourney
-  - Provider abstraction for image models
-  - Caching integration for generated images
-- **Video understanding**: Video analysis across providers
-- **Advanced vision capabilities**: OCR, object detection, image classification
-
-### Enterprise Features
-- **Geographic routing**: Route to nearest provider for latency
-  - Router integration with geo-aware strategy
-  - OpenTelemetry metrics for latency by region
-- **Multi-tenancy support**: Tenant isolation and resource management
-  - Security middleware integration for tenant authentication
-  - Cost tracking middleware per tenant
-  - Separate circuit breakers per tenant
-- **Advanced rate limiting**: Per-tenant, per-model, per-endpoint
-  - Security middleware enhancement
-  - OpenTelemetry metrics for rate limit hits
-  - Integration with existing health checks
-- **Audit logging and compliance**: Request/response audit trail
-  - Logging middleware integration
-  - OpenTelemetry events for audit trail
-  - Conversation history middleware for full context preservation
-- **SSO integration**: Enterprise authentication support
-  - Security middleware enhancement
-  - OpenID Connect, SAML support
-
-### Performance Optimizations
-- **Request deduplication**: Collapse identical concurrent requests
-  - Middleware implementation
-  - Caching middleware integration for dedup detection
-  - OpenTelemetry metrics for dedup hit rate
-- **Batch request optimization**: Automatic batching for supported providers
-  - Router enhancement for batch dispatch
-  - Cost tracking middleware for batched requests
-- **Response compression**: Gzip/brotli for HTTP responses
-  - HTTP core utilities enhancement
-  - OpenTelemetry metrics for compression ratios
-- **Parallel dispatch improvements**: Enhanced parallel execution
-  - Router enhancement with improved concurrency control
-  - OpenTelemetry distributed tracing for parallel requests
-  - Circuit breaker integration (fail fast for unavailable backends)
-
-### Developer Experience
-- **VSCode extension**: Code snippets, autocomplete, inline docs
-  - TypeScript integration with type inference
-  - Quick provider switching
-  - OpenTelemetry trace viewer integration
-- **Browser debugging extension**: Chrome DevTools integration
-  - Request/response inspection
-  - Middleware pipeline visualization
-  - OpenTelemetry trace correlation
-  - Circuit breaker status display
-- **Interactive code playground**: Web-based REPL
-  - Powered by existing backend adapters
-  - Mock provider for demo without API keys
-  - React integration examples
-- **"Awesome ai.matey" community list**: Curated resources
-  - Community adapters, middleware, examples
-- **Community adapter marketplace**: Discoverability platform
-  - Testing utilities integration for adapter validation
-  - OpenTelemetry-instrumented examples
-
-### Advanced Features
-- **Machine learning optimization**: Learn optimal models from usage patterns
-  - Cost tracking middleware data for training
-  - OpenTelemetry metrics for model performance
-  - Router integration for automatic model selection
-- **Model recommendations**: Suggest cheaper/better alternatives
-  - Cost tracking middleware integration
-  - Capability matching based on actual usage
-  - OpenTelemetry metrics for recommendation acceptance
-- **Dynamic pricing**: Real-time pricing API integration
-  - Cost tracking middleware enhancement
-  - Router integration for cost-based routing
-  - OpenTelemetry metrics for pricing fluctuations
-- **Advanced capability matching**: Match requests to capable models
-  - Router enhancement with capability awareness
-  - Uses existing provider metadata
-- **Prompt template system**: Versioned prompt management
-  - Transform middleware integration
-  - Conversation history middleware for template context
-  - Validation middleware for template compliance
-
-### Ecosystem Expansion
-- **SvelteKit integration**: Server-side actions and stores
-  - Similar to existing Next.js integration
-  - React core hooks adapted for Svelte
-  - HTTP integration with SvelteKit endpoints
-- **Vue.js composables**: `useChat`, `useCompletion` for Vue 3
-  - Similar to React hooks architecture
-  - Composables package following existing pattern
-- **WebLLM browser integration**: Hybrid local+cloud models
-  - Browser backend adapter (similar to Chrome AI)
-  - Router integration for local-first strategy
-  - Fallback to cloud providers when local unavailable
-- **Plugin system**: Extensible middleware and adapter registry
-  - Middleware pipeline enhancement
-  - Testing utilities for plugin validation
-  - OpenTelemetry integration for plugin metrics
-- **Community adapter registry**: NPM-based adapter discovery
-  - Standard adapter interface compliance
-  - Testing utilities for community adapters
-  - OpenTelemetry metrics reporting standard
 
 ## CI/CD & Infrastructure
 

--- a/examples/browser/litert-lm.html
+++ b/examples/browser/litert-lm.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<!--
+  LiteRT-LM on-device chat demo.
+
+  Serve with cross-origin isolation, e.g.:
+    npx serve --cors -l 8787 . # then add COOP/COEP via a real server if needed
+  Requires a WebGPU-capable browser (Chrome 113+). First load downloads the
+  model bundle (hundreds of MB) — subsequent loads reuse the compiled engine.
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>ai.matey × LiteRT-LM</title>
+  </head>
+  <body>
+    <h1>ai.matey × LiteRT-LM (on-device Gemma)</h1>
+    <input id="prompt" size="60" value="Write a haiku about tide pools." />
+    <button id="send">Send</button>
+    <pre id="out"></pre>
+
+    <script type="module">
+      import { Bridge } from 'https://esm.sh/ai.matey.core';
+      import { OpenAIFrontendAdapter } from 'https://esm.sh/ai.matey.frontend';
+      import { LiteRtLmBackendAdapter } from 'https://esm.sh/ai.matey.backend.browser';
+
+      const backend = new LiteRtLmBackendAdapter({
+        model:
+          'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it-web.litertlm',
+      });
+      const bridge = new Bridge(new OpenAIFrontendAdapter(), backend);
+      const out = document.getElementById('out');
+
+      document.getElementById('send').addEventListener('click', async () => {
+        out.textContent = '(loading model on first run…)\n';
+        for await (const chunk of bridge.chatStream({
+          model: 'gemma-4-E2B-it-litert-lm',
+          messages: [{ role: 'user', content: document.getElementById('prompt').value }],
+          stream: true,
+        })) {
+          out.textContent += chunk.choices?.[0]?.delta?.content ?? '';
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16703,7 +16703,7 @@
       }
     },
     "packages/ai.matey.utils": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "ai.matey.errors": "*",
@@ -16745,7 +16745,7 @@
     },
     "packages/backend-browser": {
       "name": "ai.matey.backend.browser",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "ai.matey.errors": "*",
@@ -16759,6 +16759,14 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@litert-lm/core": "*"
+      },
+      "peerDependenciesMeta": {
+        "@litert-lm/core": {
+          "optional": true
+        }
       }
     },
     "packages/cli": {
@@ -16969,7 +16977,7 @@
     },
     "packages/native-node-llamacpp": {
       "name": "ai.matey.native.node-llamacpp",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "ai.matey.errors": "*",
@@ -16983,6 +16991,14 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "node-llama-cpp": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-llama-cpp": {
+          "optional": true
+        }
       }
     },
     "packages/patterns": {

--- a/packages/ai.matey.utils/CHANGELOG.md
+++ b/packages/ai.matey.utils/CHANGELOG.md
@@ -1,5 +1,16 @@
 # ai.matey.utils
 
+## 0.4.1
+
+### Patch Changes
+
+- New LiteRT-LM backend adapter: run Gemma on-device in the browser via WebGPU
+  (`@litert-lm/core`, optional peer). Streaming-native with engine caching per model URL,
+  AbortSignal cancellation, and semantic-drift warnings for the Web SDK's dropped features
+  (sampler params, tools, non-text content). Registry entries for Gemma-4 E2B/E4B. Also:
+  node-llama-cpp is now properly declared as an optional peer dependency of
+  ai.matey.native.node-llamacpp.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/ai.matey.utils/package.json
+++ b/packages/ai.matey.utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.matey.utils",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Utility functions for AI Matey - Universal AI Adapter System",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/packages/ai.matey.utils/src/model-registry-data.ts
+++ b/packages/ai.matey.utils/src/model-registry-data.ts
@@ -651,6 +651,36 @@ export const MODEL_REGISTRY_SEED: readonly ModelRegistryEntry[] = [
   },
 
   // ==========================================================================
+  // LiteRT-LM (on-device, browser/WebGPU — $0)
+  // ==========================================================================
+  {
+    id: 'gemma-4-E2B-it-litert-lm',
+    provider: 'litert-lm',
+    family: 'gemma-4',
+    aliases: ['gemma-4-E2B-it-web'],
+    releaseDate: '2026-05-01',
+    contextWindow: 8192,
+    maxOutputTokens: 8192,
+    pricing: { inputPer1M: 0, outputPer1M: 0 },
+    capabilities: { streaming: true, vision: false, tools: false, json: false },
+    latency: { p50: 400, p95: 1500 },
+    qualityScore: 62,
+  },
+  {
+    id: 'gemma-4-E4B-it-litert-lm',
+    provider: 'litert-lm',
+    family: 'gemma-4',
+    aliases: ['gemma-4-E4B-it-web'],
+    releaseDate: '2026-05-01',
+    contextWindow: 8192,
+    maxOutputTokens: 8192,
+    pricing: { inputPer1M: 0, outputPer1M: 0 },
+    capabilities: { streaming: true, vision: false, tools: false, json: false },
+    latency: { p50: 700, p95: 2500 },
+    qualityScore: 70,
+  },
+
+  // ==========================================================================
   // xAI
   // ==========================================================================
   {

--- a/packages/backend-browser/CHANGELOG.md
+++ b/packages/backend-browser/CHANGELOG.md
@@ -1,5 +1,21 @@
 # ai.matey.backend.browser
 
+## 0.4.0
+
+### Minor Changes
+
+- New LiteRT-LM backend adapter: run Gemma on-device in the browser via WebGPU
+  (`@litert-lm/core`, optional peer). Streaming-native with engine caching per model URL,
+  AbortSignal cancellation, and semantic-drift warnings for the Web SDK's dropped features
+  (sampler params, tools, non-text content). Registry entries for Gemma-4 E2B/E4B. Also:
+  node-llama-cpp is now properly declared as an optional peer dependency of
+  ai.matey.native.node-llamacpp.
+
+### Patch Changes
+
+- Updated dependencies
+  - ai.matey.utils@0.4.1
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/backend-browser/package.json
+++ b/packages/backend-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.matey.backend.browser",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Browser-compatible backend adapters for AI Matey - Chrome AI, Function, Mock",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -101,5 +101,13 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "browser": "./dist/esm/index.js"
+  "browser": "./dist/esm/index.js",
+  "peerDependencies": {
+    "@litert-lm/core": "*"
+  },
+  "peerDependenciesMeta": {
+    "@litert-lm/core": {
+      "optional": true
+    }
+  }
 }

--- a/packages/backend-browser/readme.md
+++ b/packages/backend-browser/readme.md
@@ -76,3 +76,51 @@ See the TypeScript definitions for detailed API documentation.
 ## License
 
 MIT - see [LICENSE](./LICENSE) for details.
+
+## LiteRT-LM (on-device LLM, WebGPU)
+
+Run Google's Gemma models entirely in the browser via [LiteRT-LM](https://developers.google.com/edge/litert-lm/js) — no API key, no server, no cost.
+
+```bash
+npm install ai.matey.backend.browser @litert-lm/core
+```
+
+```typescript
+import { Bridge } from 'ai.matey.core';
+import { OpenAIFrontendAdapter } from 'ai.matey.frontend';
+import { LiteRtLmBackendAdapter } from 'ai.matey.backend.browser';
+
+const backend = new LiteRtLmBackendAdapter({
+  model:
+    'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it-web.litertlm',
+  maxNumTokens: 8192,
+});
+
+const bridge = new Bridge(new OpenAIFrontendAdapter(), backend);
+
+for await (const chunk of bridge.chatStream({
+  model: 'gemma-4-E2B-it-litert-lm',
+  messages: [{ role: 'user', content: 'Write a haiku about tide pools.' }],
+  stream: true,
+})) {
+  render(chunk.choices?.[0]?.delta?.content ?? '');
+}
+
+// Free GPU/WASM memory when done with the model
+await backend.dispose();
+```
+
+### Requirements & notes
+
+- **WebGPU** (Chrome 113+, Safari 17.4+, Firefox 121+). Browser only — no Node.js.
+- **Cross-origin isolation** may be required for threaded WASM: serve your page with
+  `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`.
+- **Model downloads are large** (hundreds of MB to GBs). Engines are cached per model URL across
+  adapter instances, so the download/compile happens once per page.
+- **Web SDK limits** (early preview): text-only, no tool calling, no sampler parameters
+  (`temperature`/`topK`/`seed` are dropped with an IR warning). Prior conversation turns are
+  flattened into a transcript prefix (each request opens a fresh conversation).
+- Models: [litert-community on Hugging Face](https://huggingface.co/litert-community) —
+  Gemma-4 E2B (faster) and E4B (better), under the Gemma license.
+- Naming note: `@litertjs/core` ("LiteRT.js") is Google's tensor-level runtime and cannot run chat
+  models — this adapter wraps **LiteRT-LM** (`@litert-lm/core`), the conversation runtime.

--- a/packages/backend-browser/src/index.ts
+++ b/packages/backend-browser/src/index.ts
@@ -15,6 +15,9 @@
 // Chrome AI adapter - uses Chrome's built-in AI
 export * from './chrome-ai.js';
 
+// LiteRT-LM adapter - Google on-device LLM (WebGPU)
+export * from './litert-lm.js';
+
 // Function adapter - custom function-based backends
 export * from './function.js';
 

--- a/packages/backend-browser/src/litert-lm.ts
+++ b/packages/backend-browser/src/litert-lm.ts
@@ -1,0 +1,510 @@
+/**
+ * LiteRT-LM Backend Adapter
+ *
+ * Runs on-device LLM chat in the browser via Google's LiteRT-LM Web runtime
+ * (`@litert-lm/core`, WebGPU). Models are `.litertlm` bundles — e.g. Gemma-4
+ * E2B/E4B from Hugging Face `litert-community` — downloaded once and executed
+ * entirely client-side: no API key, no network calls after model load, no cost.
+ *
+ * `@litert-lm/core` is an OPTIONAL peer dependency, loaded lazily so this
+ * package stays dependency-free for consumers that don't use this adapter.
+ *
+ * Web SDK limitations (early preview) surfaced as IR warnings when relevant:
+ * text-only (no vision/audio), no tool calling, and no sampler parameters
+ * (temperature/topK/topP/seed). WebGPU is required (Chrome 113+, Safari
+ * 17.4+, Firefox 121+), and cross-origin isolation (COOP/COEP headers) may be
+ * needed for threaded WASM. Not supported in Node.js.
+ *
+ * Note on naming: "LiteRT.js" (`@litertjs/core`) is Google's tensor-level
+ * runtime and cannot run chat models; this adapter wraps LiteRT-LM, the
+ * conversation runtime built on LiteRT.
+ *
+ * @module
+ */
+
+import type {
+  BackendAdapter,
+  AdapterMetadata,
+  IRChatRequest,
+  IRChatResponse,
+  IRChatStream,
+  IRMessage,
+  IRStreamChunk,
+  IRWarning,
+} from 'ai.matey.types';
+import { AdapterError, ProviderError, ErrorCode } from 'ai.matey.errors';
+import { createWarning } from 'ai.matey.utils';
+
+// ============================================================================
+// Structural types for @litert-lm/core (kept local: the peer is optional, so
+// its types cannot appear in published declarations)
+// ============================================================================
+
+/** A streamed chunk from LiteRT-LM: content items, text ones carry `text`. */
+interface LiteRtLmChunk {
+  content: Array<{ type: string; text?: string }>;
+}
+
+interface LiteRtLmConversation {
+  sendMessage(text: string): Promise<LiteRtLmChunk>;
+  sendMessageStreaming(text: string): AsyncIterable<LiteRtLmChunk>;
+  cancel(): void;
+}
+
+interface LiteRtLmEngine {
+  createConversation(options?: {
+    preface?: { messages: Array<{ role: string; content: string }> };
+  }): Promise<LiteRtLmConversation>;
+  delete(): Promise<void>;
+}
+
+/** The subset of the `@litert-lm/core` module surface this adapter uses. */
+export interface LiteRtLmModule {
+  Engine: {
+    create(options: {
+      model: string | Blob | ReadableStream;
+      mainExecutorSettings?: { maxNumTokens?: number };
+    }): Promise<LiteRtLmEngine>;
+  };
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/**
+ * Configuration for the LiteRT-LM backend adapter.
+ */
+export interface LiteRtLmConfig {
+  /**
+   * The `.litertlm` model bundle: a URL (cached per URL across adapter
+   * instances) or a Blob (cached per adapter instance only).
+   *
+   * @example 'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it-web.litertlm'
+   */
+  model: string | Blob;
+
+  /**
+   * Maximum tokens for the engine's main executor.
+   * @default 8192
+   */
+  maxNumTokens?: number;
+
+  /**
+   * Test/DI seam: a preloaded module implementing the `@litert-lm/core`
+   * surface. When omitted, the adapter dynamically imports the optional
+   * peer dependency.
+   */
+  engineModule?: LiteRtLmModule;
+}
+
+// ============================================================================
+// SDK loading + engine cache
+// ============================================================================
+
+/**
+ * Lazily import the optional peer dependency with a friendly failure.
+ */
+async function loadLiteRtLm(): Promise<LiteRtLmModule> {
+  try {
+    // @ts-expect-error - Optional peer dependency, may not be installed
+    return (await import('@litert-lm/core')) as LiteRtLmModule;
+  } catch (error) {
+    throw new AdapterError({
+      code: ErrorCode.UNSUPPORTED_FEATURE,
+      message:
+        "LiteRT-LM backend requires the optional peer dependency '@litert-lm/core' — " +
+        'install it with: npm install @litert-lm/core (browser/WebGPU only)',
+      isRetryable: false,
+      provenance: { backend: 'litert-lm-backend' },
+      cause: error instanceof Error ? error : undefined,
+    });
+  }
+}
+
+/**
+ * Engines keyed by model URL so multi-GB bundles are downloaded and compiled
+ * once per page, shared across adapter instances. Blob models are cached on
+ * the adapter instance instead (no stable global key).
+ */
+const engineCacheByUrl = new Map<string, Promise<LiteRtLmEngine>>();
+
+/**
+ * Test hook: clear the shared engine cache.
+ */
+export function clearLiteRtLmEngineCache(): void {
+  engineCacheByUrl.clear();
+}
+
+// ============================================================================
+// LiteRT-LM Backend Adapter
+// ============================================================================
+
+/**
+ * Backend adapter for Google's LiteRT-LM Web runtime.
+ *
+ * @example
+ * ```typescript
+ * import { Bridge } from 'ai.matey.core';
+ * import { OpenAIFrontendAdapter } from 'ai.matey.frontend';
+ * import { LiteRtLmBackendAdapter } from 'ai.matey.backend.browser';
+ *
+ * const backend = new LiteRtLmBackendAdapter({
+ *   model:
+ *     'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it-web.litertlm',
+ * });
+ *
+ * const bridge = new Bridge(new OpenAIFrontendAdapter(), backend);
+ * for await (const chunk of bridge.chatStream({
+ *   model: 'gemma-4-E2B-it-litert-lm', // informational; the loaded bundle decides
+ *   messages: [{ role: 'user', content: 'Hello!' }],
+ *   stream: true,
+ * })) {
+ *   process(chunk);
+ * }
+ * ```
+ */
+export class LiteRtLmBackendAdapter implements BackendAdapter {
+  readonly metadata: AdapterMetadata;
+  private readonly config: LiteRtLmConfig;
+  private instanceEngine: Promise<LiteRtLmEngine> | null = null;
+
+  constructor(config: LiteRtLmConfig) {
+    this.config = config;
+    this.metadata = {
+      name: 'litert-lm-backend',
+      version: '1.0.0',
+      provider: 'LiteRT-LM',
+      capabilities: {
+        streaming: true,
+        multiModal: false,
+        tools: false,
+        embeddings: false,
+        maxContextTokens: config.maxNumTokens ?? 8192,
+        systemMessageStrategy: 'separate-parameter',
+        supportsMultipleSystemMessages: false,
+        supportsTemperature: false,
+        supportsTopP: false,
+        supportsTopK: false,
+        supportsSeed: false,
+        supportsFrequencyPenalty: false,
+        supportsPresencePenalty: false,
+        maxStopSequences: 0,
+      },
+      config: {
+        model: typeof config.model === 'string' ? config.model : '[blob]',
+      },
+    };
+  }
+
+  /**
+   * Convert IR request to provider format (passthrough - uses IR internally).
+   */
+  fromIR(request: IRChatRequest): IRChatRequest {
+    return request;
+  }
+
+  /**
+   * Convert provider response to IR format (passthrough - uses IR internally).
+   */
+  toIR(
+    response: IRChatResponse,
+    _originalRequest: IRChatRequest,
+    _latencyMs: number
+  ): IRChatResponse {
+    return response;
+  }
+
+  /**
+   * Execute a chat request (consumes the stream internally — LiteRT-LM is
+   * streaming-native).
+   */
+  async execute(request: IRChatRequest, signal?: AbortSignal): Promise<IRChatResponse> {
+    const chunks: string[] = [];
+    for await (const chunk of this.executeStream(request, signal)) {
+      if (chunk.type === 'content') {
+        chunks.push(chunk.delta);
+      } else if (chunk.type === 'done') {
+        return {
+          message: chunk.message ?? { role: 'assistant', content: chunks.join('') },
+          finishReason: chunk.finishReason,
+          usage: chunk.usage,
+          metadata: {
+            ...request.metadata,
+            warnings: [...(request.metadata.warnings ?? []), ...this.collectWarnings(request)],
+            provenance: { ...request.metadata.provenance, backend: this.metadata.name },
+          },
+        };
+      } else if (chunk.type === 'error') {
+        throw new ProviderError({
+          code: ErrorCode.PROVIDER_ERROR,
+          message: chunk.error.message,
+          provenance: { backend: this.metadata.name },
+        });
+      }
+    }
+
+    // Fallback (stream ended without a done chunk)
+    return {
+      message: { role: 'assistant', content: chunks.join('') },
+      finishReason: 'stop',
+      metadata: {
+        ...request.metadata,
+        provenance: { ...request.metadata.provenance, backend: this.metadata.name },
+      },
+    };
+  }
+
+  /**
+   * Execute a streaming chat request through LiteRT-LM.
+   */
+  async *executeStream(request: IRChatRequest, signal?: AbortSignal): IRChatStream {
+    let conversation: LiteRtLmConversation | null = null;
+
+    try {
+      const engine = await this.getEngine();
+
+      const { preface, prompt } = this.buildConversationInput(request);
+      conversation = await engine.createConversation(
+        preface.length > 0 ? { preface: { messages: preface } } : {}
+      );
+
+      let sequence = 0;
+
+      yield {
+        type: 'start',
+        sequence: sequence++,
+        metadata: {
+          ...request.metadata,
+          warnings: [...(request.metadata.warnings ?? []), ...this.collectWarnings(request)],
+          provenance: { ...request.metadata.provenance, backend: this.metadata.name },
+        },
+      } as IRStreamChunk;
+
+      let buffer = '';
+
+      for await (const chunk of conversation.sendMessageStreaming(prompt)) {
+        if (signal?.aborted) {
+          conversation.cancel();
+          throw new ProviderError({
+            code: ErrorCode.PROVIDER_ERROR,
+            message: 'LiteRT-LM generation aborted',
+            provenance: { backend: this.metadata.name },
+          });
+        }
+
+        for (const item of chunk.content) {
+          if (item.type === 'text' && item.text) {
+            buffer += item.text;
+            yield {
+              type: 'content',
+              sequence: sequence++,
+              delta: item.text,
+              role: 'assistant',
+            } as IRStreamChunk;
+          }
+        }
+      }
+
+      const message: IRMessage = { role: 'assistant', content: buffer };
+      yield {
+        type: 'done',
+        sequence: sequence++,
+        finishReason: 'stop',
+        message,
+      } as IRStreamChunk;
+    } catch (error) {
+      conversation?.cancel();
+      yield {
+        type: 'error',
+        sequence: 0,
+        error: {
+          code: error instanceof AdapterError ? error.code : 'PROVIDER_ERROR',
+          message: error instanceof Error ? error.message : String(error),
+        },
+      } as IRStreamChunk;
+    }
+  }
+
+  /**
+   * Release the engine held by this adapter (and the shared cache entry for
+   * URL models). Frees GPU/WASM memory.
+   */
+  async dispose(): Promise<void> {
+    const cached =
+      typeof this.config.model === 'string'
+        ? engineCacheByUrl.get(this.config.model)
+        : this.instanceEngine;
+
+    if (typeof this.config.model === 'string') {
+      engineCacheByUrl.delete(this.config.model);
+    }
+    this.instanceEngine = null;
+
+    if (cached) {
+      try {
+        const engine = await cached;
+        await engine.delete();
+      } catch {
+        // Engine failed to initialize; nothing to free
+      }
+    }
+  }
+
+  // ==========================================================================
+  // Private helpers
+  // ==========================================================================
+
+  /**
+   * Get (or create) the engine — shared per model URL, per-instance for Blobs.
+   */
+  private getEngine(): Promise<LiteRtLmEngine> {
+    const { model } = this.config;
+
+    if (typeof model === 'string') {
+      let cached = engineCacheByUrl.get(model);
+      if (!cached) {
+        cached = this.createEngine();
+        engineCacheByUrl.set(model, cached);
+        // Drop failed initializations so retries re-attempt
+        cached.catch(() => engineCacheByUrl.delete(model));
+      }
+      return cached;
+    }
+
+    if (!this.instanceEngine) {
+      this.instanceEngine = this.createEngine();
+      this.instanceEngine.catch(() => {
+        this.instanceEngine = null;
+      });
+    }
+    return this.instanceEngine;
+  }
+
+  private async createEngine(): Promise<LiteRtLmEngine> {
+    const module = this.config.engineModule ?? (await loadLiteRtLm());
+    return module.Engine.create({
+      model: this.config.model,
+      mainExecutorSettings: { maxNumTokens: this.config.maxNumTokens ?? 8192 },
+    });
+  }
+
+  /**
+   * Map IR messages onto LiteRT-LM's conversation model.
+   *
+   * System messages become the conversation preface. Because each request
+   * creates a fresh conversation, prior turns are flattened into a
+   * transcript-style prefix on the outgoing prompt (portable across the
+   * early-preview API; a warning notes the flattening when it happens).
+   */
+  private buildConversationInput(request: IRChatRequest): {
+    preface: Array<{ role: string; content: string }>;
+    prompt: string;
+  } {
+    const preface: Array<{ role: string; content: string }> = [];
+    const turns: Array<{ role: string; text: string }> = [];
+
+    for (const message of request.messages) {
+      const text = extractText(message);
+      if (message.role === 'system') {
+        preface.push({ role: 'system', content: text });
+      } else {
+        turns.push({ role: message.role, text });
+      }
+    }
+
+    const last = turns.pop();
+    const prompt = last?.text ?? '';
+
+    if (turns.length === 0) {
+      return { preface, prompt };
+    }
+
+    // Flatten earlier turns into a readable transcript prefix
+    const transcript = turns
+      .map((turn) => `${turn.role === 'assistant' ? 'Assistant' : 'User'}: ${turn.text}`)
+      .join('\n');
+
+    return {
+      preface,
+      prompt: `Previous conversation:\n${transcript}\n\nUser: ${prompt}`,
+    };
+  }
+
+  /**
+   * Warnings for request features the LiteRT-LM Web SDK drops.
+   */
+  private collectWarnings(request: IRChatRequest): IRWarning[] {
+    const warnings: IRWarning[] = [];
+
+    const droppedParameters = (['temperature', 'topP', 'topK', 'seed'] as const).filter(
+      (key) => request.parameters?.[key] !== undefined
+    );
+    for (const parameter of droppedParameters) {
+      warnings.push(
+        createWarning(
+          'parameter-unsupported',
+          `LiteRT-LM Web does not support '${parameter}'; the parameter was dropped`,
+          { field: `parameters.${parameter}`, source: this.metadata.name }
+        )
+      );
+    }
+
+    if (request.tools && request.tools.length > 0) {
+      warnings.push(
+        createWarning('tool-unsupported', 'LiteRT-LM Web does not support tool calling', {
+          source: this.metadata.name,
+        })
+      );
+    }
+
+    const hasNonText = request.messages.some(
+      (message) =>
+        typeof message.content !== 'string' &&
+        message.content.some((block) => block.type !== 'text')
+    );
+    if (hasNonText) {
+      warnings.push(
+        createWarning(
+          'content-type-unsupported',
+          'LiteRT-LM Web is text-only; non-text content blocks were reduced to text',
+          { source: this.metadata.name }
+        )
+      );
+    }
+
+    const flattenedTurns =
+      request.messages.filter((message) => message.role !== 'system').length > 1;
+    if (flattenedTurns) {
+      warnings.push(
+        createWarning(
+          'system-message-transformed',
+          'Prior turns were flattened into a transcript prefix (fresh LiteRT-LM conversation per request)',
+          { source: this.metadata.name }
+        )
+      );
+    }
+
+    return warnings;
+  }
+}
+
+/**
+ * Extract plain text from an IR message (text blocks only).
+ */
+function extractText(message: IRMessage): string {
+  if (typeof message.content === 'string') {
+    return message.content;
+  }
+  return message.content
+    .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
+    .map((block) => block.text)
+    .join('');
+}
+
+/**
+ * Create a LiteRT-LM backend adapter.
+ */
+export function createLiteRtLmAdapter(config: LiteRtLmConfig): LiteRtLmBackendAdapter {
+  return new LiteRtLmBackendAdapter(config);
+}

--- a/packages/native-node-llamacpp/CHANGELOG.md
+++ b/packages/native-node-llamacpp/CHANGELOG.md
@@ -1,0 +1,14 @@
+# ai.matey.native.node-llamacpp
+
+## 0.2.1
+
+### Patch Changes
+
+- New LiteRT-LM backend adapter: run Gemma on-device in the browser via WebGPU
+  (`@litert-lm/core`, optional peer). Streaming-native with engine caching per model URL,
+  AbortSignal cancellation, and semantic-drift warnings for the Web SDK's dropped features
+  (sampler params, tools, non-text content). Registry entries for Gemma-4 E2B/E4B. Also:
+  node-llama-cpp is now properly declared as an optional peer dependency of
+  ai.matey.native.node-llamacpp.
+- Updated dependencies
+  - ai.matey.utils@0.4.1

--- a/packages/native-node-llamacpp/package.json
+++ b/packages/native-node-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.matey.native.node-llamacpp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "node-llamacpp native backend for AI Matey",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -67,5 +67,13 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "peerDependencies": {
+    "node-llama-cpp": ">=3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "node-llama-cpp": {
+      "optional": true
+    }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -424,6 +424,7 @@ import { OpenAIBackendAdapter } from 'ai.matey.backend/openai';
 
 Subset of adapters that work in browser environments:
 - Chrome AI
+- LiteRT-LM (on-device Gemma via WebGPU)
 - Mock (testing)
 - Function (testing)
 

--- a/tests/unit/litert-lm.test.ts
+++ b/tests/unit/litert-lm.test.ts
@@ -1,0 +1,267 @@
+/**
+ * LiteRT-LM backend adapter tests
+ *
+ * @litert-lm/core is browser/WebGPU-only, so these tests exercise the adapter
+ * through its `engineModule` injection seam with a scripted fake engine.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  LiteRtLmBackendAdapter,
+  clearLiteRtLmEngineCache,
+  type LiteRtLmModule,
+} from 'ai.matey.backend.browser';
+import type { IRChatRequest, StreamContentChunk } from 'ai.matey.types';
+
+// ============================================================================
+// Fake engine
+// ============================================================================
+
+interface FakeState {
+  createCalls: Array<{ model: unknown; maxNumTokens?: number }>;
+  conversations: Array<{
+    preface?: { messages: Array<{ role: string; content: string }> };
+    sent: string[];
+    cancelled: boolean;
+  }>;
+  deleted: number;
+}
+
+function makeFakeModule(
+  replyChunks: string[] = ['Hello', ' from', ' Gemma'],
+  options: { delayMs?: number } = {}
+): { module: LiteRtLmModule; state: FakeState } {
+  const state: FakeState = { createCalls: [], conversations: [], deleted: 0 };
+
+  const module: LiteRtLmModule = {
+    Engine: {
+      // eslint-disable-next-line @typescript-eslint/require-await -- fake SDK surface
+      create: async (createOptions) => {
+        state.createCalls.push({
+          model: createOptions.model,
+          maxNumTokens: createOptions.mainExecutorSettings?.maxNumTokens,
+        });
+        return {
+          // eslint-disable-next-line @typescript-eslint/require-await -- fake SDK surface
+          createConversation: async (conversationOptions) => {
+            const record = {
+              preface: conversationOptions?.preface,
+              sent: [] as string[],
+              cancelled: false,
+            };
+            state.conversations.push(record);
+            return {
+              // eslint-disable-next-line @typescript-eslint/require-await -- fake SDK surface
+              sendMessage: async (text: string) => {
+                record.sent.push(text);
+                return { content: [{ type: 'text', text: replyChunks.join('') }] };
+              },
+              sendMessageStreaming: (text: string) => {
+                record.sent.push(text);
+                return (async function* () {
+                  for (const chunk of replyChunks) {
+                    if (options.delayMs) {
+                      await new Promise((resolve) => setTimeout(resolve, options.delayMs));
+                    }
+                    yield { content: [{ type: 'text', text: chunk }] };
+                  }
+                })();
+              },
+              cancel: () => {
+                record.cancelled = true;
+              },
+            };
+          },
+          // eslint-disable-next-line @typescript-eslint/require-await -- fake SDK surface
+          delete: async () => {
+            state.deleted++;
+          },
+        };
+      },
+    },
+  };
+
+  return { module, state };
+}
+
+function makeRequest(overrides: Partial<IRChatRequest> = {}): IRChatRequest {
+  return {
+    messages: [{ role: 'user', content: 'Hi there' }],
+    parameters: {},
+    metadata: { requestId: 'r1', timestamp: Date.now(), provenance: {} },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  clearLiteRtLmEngineCache();
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('LiteRtLmBackendAdapter', () => {
+  it('streams content chunks and assembles the done message', async () => {
+    const { module } = makeFakeModule(['One', ' two', ' three']);
+    const adapter = new LiteRtLmBackendAdapter({ model: 'https://x/m.litertlm', engineModule: module });
+
+    const chunks = [];
+    for await (const chunk of adapter.executeStream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    const deltas = chunks
+      .filter((chunk): chunk is StreamContentChunk => chunk.type === 'content')
+      .map((chunk) => chunk.delta);
+    expect(deltas).toEqual(['One', ' two', ' three']);
+
+    const done = chunks.find((chunk) => chunk.type === 'done');
+    expect(done?.type === 'done' && done.message?.content).toBe('One two three');
+    expect(done?.type === 'done' && done.finishReason).toBe('stop');
+  });
+
+  it('execute() consumes the stream into a response', async () => {
+    const { module } = makeFakeModule(['Complete answer']);
+    const adapter = new LiteRtLmBackendAdapter({ model: 'https://x/m.litertlm', engineModule: module });
+
+    const response = await adapter.execute(makeRequest());
+    expect(response.message.content).toBe('Complete answer');
+    expect(response.metadata.provenance?.backend).toBe('litert-lm-backend');
+  });
+
+  it('maps system messages to the conversation preface', async () => {
+    const { module, state } = makeFakeModule();
+    const adapter = new LiteRtLmBackendAdapter({ model: 'https://x/m.litertlm', engineModule: module });
+
+    await adapter.execute(
+      makeRequest({
+        messages: [
+          { role: 'system', content: 'You are terse.' },
+          { role: 'user', content: 'Hi' },
+        ],
+      })
+    );
+
+    expect(state.conversations[0]?.preface?.messages).toEqual([
+      { role: 'system', content: 'You are terse.' },
+    ]);
+    expect(state.conversations[0]?.sent).toEqual(['Hi']);
+  });
+
+  it('flattens prior turns into a transcript prefix with a warning', async () => {
+    const { module, state } = makeFakeModule();
+    const adapter = new LiteRtLmBackendAdapter({ model: 'https://x/m.litertlm', engineModule: module });
+
+    const response = await adapter.execute(
+      makeRequest({
+        messages: [
+          { role: 'user', content: 'What is 2+2?' },
+          { role: 'assistant', content: '4' },
+          { role: 'user', content: 'And doubled?' },
+        ],
+      })
+    );
+
+    const sent = state.conversations[0]?.sent[0] ?? '';
+    expect(sent).toContain('Previous conversation:');
+    expect(sent).toContain('User: What is 2+2?');
+    expect(sent).toContain('Assistant: 4');
+    expect(sent).toContain('User: And doubled?');
+
+    expect(
+      response.metadata.warnings?.some((warning) => warning.category === 'system-message-transformed')
+    ).toBe(true);
+  });
+
+  it('warns when dropping unsupported parameters, tools, and non-text content', async () => {
+    const { module } = makeFakeModule();
+    const adapter = new LiteRtLmBackendAdapter({ model: 'https://x/m.litertlm', engineModule: module });
+
+    const response = await adapter.execute(
+      makeRequest({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Describe this' },
+              { type: 'image', source: { type: 'url', url: 'https://x/cat.png' } },
+            ],
+          },
+        ],
+        parameters: { temperature: 0.7, topK: 40 },
+        tools: [
+          { name: 'noop', description: '', parameters: { type: 'object', properties: {} } },
+        ],
+      })
+    );
+
+    const categories = (response.metadata.warnings ?? []).map((warning) => warning.category);
+    expect(categories).toContain('parameter-unsupported');
+    expect(categories).toContain('tool-unsupported');
+    expect(categories).toContain('content-type-unsupported');
+  });
+
+  it('cancels the conversation on abort', async () => {
+    const { module, state } = makeFakeModule(['a', 'b', 'c', 'd'], { delayMs: 10 });
+    const adapter = new LiteRtLmBackendAdapter({ model: 'https://x/m.litertlm', engineModule: module });
+
+    const controller = new AbortController();
+    const chunks = [];
+    for await (const chunk of adapter.executeStream(makeRequest(), controller.signal)) {
+      chunks.push(chunk);
+      if (chunks.filter((c) => c.type === 'content').length === 1) {
+        controller.abort();
+      }
+    }
+
+    expect(state.conversations[0]?.cancelled).toBe(true);
+    expect(chunks.at(-1)?.type).toBe('error');
+  });
+
+  it('caches one engine per model URL across adapter instances', async () => {
+    const { module, state } = makeFakeModule();
+    const first = new LiteRtLmBackendAdapter({ model: 'https://x/same.litertlm', engineModule: module });
+    const second = new LiteRtLmBackendAdapter({ model: 'https://x/same.litertlm', engineModule: module });
+
+    await first.execute(makeRequest());
+    await second.execute(makeRequest());
+
+    expect(state.createCalls).toHaveLength(1);
+    expect(state.createCalls[0]?.maxNumTokens).toBe(8192);
+  });
+
+  it('dispose() deletes the engine and clears the cache entry', async () => {
+    const { module, state } = makeFakeModule();
+    const adapter = new LiteRtLmBackendAdapter({ model: 'https://x/m.litertlm', engineModule: module });
+
+    await adapter.execute(makeRequest());
+    await adapter.dispose();
+    expect(state.deleted).toBe(1);
+
+    await adapter.execute(makeRequest());
+    expect(state.createCalls).toHaveLength(2); // cache entry was cleared
+  });
+
+  it('yields a friendly error when the peer module is missing', async () => {
+    const adapter = new LiteRtLmBackendAdapter({ model: 'https://x/m.litertlm' });
+
+    const chunks = [];
+    for await (const chunk of adapter.executeStream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    const error = chunks.find((chunk) => chunk.type === 'error');
+    expect(error?.type === 'error' && error.error.message).toContain('@litert-lm/core');
+  });
+
+  it('advertises accurate capabilities', () => {
+    const adapter = new LiteRtLmBackendAdapter({ model: 'https://x/m.litertlm' });
+    const caps = adapter.metadata.capabilities;
+
+    expect(caps.streaming).toBe(true);
+    expect(caps.tools).toBe(false);
+    expect(caps.multiModal).toBe(false);
+    expect(caps.supportsTemperature).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

### LiteRT-LM backend (`ai.matey.backend.browser` → 0.4.0)
Run Gemma **on-device in the browser** via Google's LiteRT-LM Web runtime (`@litert-lm/core`, optional peer, WebGPU) — no API key, no server, zero cost:
- `LiteRtLmBackendAdapter` / `createLiteRtLmAdapter()`: streaming-native, engine cached per model URL (multi-GB bundles compile once per page), `dispose()` frees GPU/WASM memory
- System messages → conversation preface; prior turns flatten to a transcript prefix (warned); AbortSignal → `cancel()`
- Semantic-drift warnings for everything the early-preview Web SDK drops (temperature/topK/seed, tools, non-text content); friendly error when the peer isn't installed
- Registry entries for Gemma-4 E2B/E4B; browser example (`examples/browser/litert-lm.html`); README docs covering WebGPU, COOP/COEP isolation, and model-size caveats
- 10 tests via an `engineModule` injection seam (the SDK is browser-only)

Research note: "LiteRT.js" (`@litertjs/core`) is Google's **tensor-only** runtime — it cannot run chat models. The on-device chat path is **LiteRT-LM**, which this wraps. MediaPipe's genai API is maintenance-mode and deliberately skipped.

### Ecosystem roadmap (docs/ROADMAP.md)
Replaced the stale priorities with a four-wave catch-up plan from a July-2026 competitive analysis (AI SDK 7, LangChain 1.0, Mastra 1.0, OpenAI Agents SDK, VoltAgent): **Wave 1** MCP client+server + Agent abstraction with approvals · **Wave 2** memory on our embeddings + guardrails · **Wave 3** speech/image/reranking, RAG, evals · **Wave 4** web-llm/transformers.js backends, Vue/Svelte hooks, devtools, pricing auto-sync — with condensed architecture designs inline so future work can execute without re-research. Positioning recorded: pure self-hosted library.

### In passing
`node-llama-cpp` is now properly declared as an optional peer of `ai.matey.native.node-llamacpp`.

Verification: 1388 tests passing, 68/68 build/lint/typecheck tasks green, `npm pack` dry-run confirms the new export + peer declarations. Versions bumped via changesets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)