### PR TITLE
Add per-provider structured/schema-constrained output support

### DIFF
--- a/.changeset/structured-output-responseformat.md
+++ b/.changeset/structured-output-responseformat.md
@@ -1,0 +1,13 @@
+---
+'ai.matey.types': minor
+'ai.matey.backend': minor
+---
+
+Add `responseFormat` to the IR request for per-provider structured/schema-constrained
+output. `IRChatRequest.responseFormat` (`{ type: 'json_schema', schema, strict? }`) reuses
+the existing `JSONSchema` type. OpenAI, Anthropic, Gemini, and their OpenAI-compatible
+inheritors (Groq, DeepSeek, Inception, Moonshot, NVIDIA, LM Studio, SambaNova) map it to
+their native structured-output mechanism; all other backends emulate it via prompt
+injection and best-effort JSON extraction. `IRCapabilities.structuredOutput` and
+`response.metadata.custom.responseFormatEnforced` let callers tell which path was used.
+(#16)

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ temp/
 web.env.local.mjs
 models/
 .claude-trace/
+.todos/

--- a/docs/IR-FORMAT.md
+++ b/docs/IR-FORMAT.md
@@ -12,6 +12,7 @@
 - [Streaming Format](#streaming-format)
 - [Metadata & Provenance](#metadata--provenance)
 - [Tools & Function Calling](#tools--function-calling)
+- [Structured Output](#structured-output)
 - [Parameters](#parameters)
 - [Capabilities](#capabilities)
 - [Examples](#examples)
@@ -243,6 +244,7 @@ interface IRChatRequest {
   readonly messages: readonly IRMessage[];
   readonly tools?: readonly IRTool[];
   readonly toolChoice?: 'auto' | 'required' | 'none' | { readonly name: string };
+  readonly responseFormat?: IRResponseFormat;
   readonly parameters?: IRParameters;
   readonly metadata: IRMetadata;
   readonly stream?: boolean;
@@ -257,6 +259,7 @@ interface IRChatRequest {
 | `messages` | `IRMessage[]` | ✅ | Conversation messages (minimum 1) |
 | `tools` | `IRTool[]` | ❌ | Available tools/functions |
 | `toolChoice` | `string \| object` | ❌ | Tool selection strategy |
+| `responseFormat` | `IRResponseFormat` | ❌ | JSON-schema-constrained output request (see [Structured Output](#structured-output)) |
 | `parameters` | `IRParameters` | ❌ | Generation parameters (temperature, etc.) |
 | `metadata` | `IRMetadata` | ✅ | Request tracking metadata |
 | `stream` | `boolean` | ❌ | Enable streaming (default: false) |
@@ -757,6 +760,62 @@ const weatherTool: IRTool = {
 
 ---
 
+## Structured Output
+
+### IRResponseFormat
+
+Requests that the backend constrain its response to a caller-supplied JSON schema. Reuses the `JSONSchema` type from [Tools & Function Calling](#tools--function-calling) - one schema type for both tool parameters and structured output.
+
+```typescript
+interface IRResponseFormat {
+  readonly type: 'json_schema';
+  readonly schema: JSONSchema;
+  readonly strict?: boolean;
+}
+```
+
+This is a **best-effort request, not a guarantee**. Callers should still validate the parsed response against their schema (e.g. with Zod) - `responseFormat` narrows the odds of malformed output, it doesn't replace consumer-side validation.
+
+### Native vs. Fallback
+
+Backends handle `responseFormat` one of two ways, reported via `IRCapabilities.structuredOutput: 'native' | 'fallback'` and, per-response, via `IRChatResponse.metadata.custom.responseFormatEnforced: boolean`:
+
+- **Native** - the backend adapter maps `responseFormat` directly onto the provider's own schema-constrained output mechanism (e.g. OpenAI's `response_format`, Anthropic's `output_config.format`, Gemini's `generationConfig.responseSchema`). The provider enforces the shape server-side.
+- **Fallback** - for backends with no native mechanism, the adapter appends a schema-instruction message to the prompt and best-effort-extracts/repairs JSON from the plain-text reply (stripping markdown code fences, locating the outermost balanced JSON span, and removing trailing commas on a single repair pass). A `capability-unsupported` `IRWarning` is added to `metadata.warnings` when this path is used.
+
+| Backend | Support |
+|---|---|
+| OpenAI | Native (`response_format: { type: 'json_schema', json_schema: { schema } }`) |
+| Anthropic | Native (`output_config: { format: { type: 'json_schema', schema } }`) |
+| Gemini | Native (`generationConfig.responseSchema` + `responseMimeType: 'application/json'`) |
+| Groq, DeepSeek, Inception, Moonshot, NVIDIA, LM Studio, SambaNova | Native (OpenAI-compatible - inherit OpenAI's mapping unchanged) |
+| All other backends (AI21, Anyscale, AWS Bedrock, Azure OpenAI, Cerebras, Cloudflare, Cohere, DeepInfra, Fireworks, Hugging Face, Mistral, Ollama, OpenRouter, Perplexity, Replicate, Together AI, xAI) | Fallback (prompt injection + best-effort JSON extraction) |
+
+### Example
+
+```typescript
+const request: IRChatRequest = {
+  messages: [{ role: 'user', content: 'Extract the name and age from: John is 30.' }],
+  responseFormat: {
+    type: 'json_schema',
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'number' }
+      },
+      required: ['name', 'age']
+    }
+  },
+  metadata: { requestId: 'req_1', timestamp: Date.now(), provenance: { frontend: 'openai' } }
+};
+
+// response.message.content -> '{"name":"John","age":30}'
+// response.metadata.custom.responseFormatEnforced -> true (native) or false (fallback)
+```
+
+---
+
 ## Parameters
 
 ### IRParameters
@@ -819,6 +878,7 @@ interface IRCapabilities {
   readonly streaming: boolean;
   readonly multiModal: boolean;
   readonly tools?: boolean;
+  readonly structuredOutput?: 'native' | 'fallback';
   readonly maxContextTokens?: number;
   readonly supportedModels?: readonly string[];
   readonly systemMessageStrategy: SystemMessageStrategy;

--- a/packages/ai.matey.types/src/ir.ts
+++ b/packages/ai.matey.types/src/ir.ts
@@ -397,6 +397,47 @@ export interface IRTool {
   readonly metadata?: Record<string, unknown>;
 }
 
+/**
+ * Structured/schema-constrained output request.
+ *
+ * Asks the backend to constrain its response to a caller-supplied JSON
+ * schema. Backends with a native mechanism (e.g. OpenAI, Anthropic, Gemini)
+ * map this directly; others emulate it via prompt injection and best-effort
+ * JSON extraction (see `IRCapabilities.structuredOutput` and
+ * `IRChatResponse.metadata.custom.responseFormatEnforced`).
+ *
+ * This is a best-effort request, not a guarantee - callers should still
+ * validate the parsed response against their schema (e.g. with Zod).
+ *
+ * @example
+ * ```typescript
+ * const responseFormat: IRResponseFormat = {
+ *   type: 'json_schema',
+ *   schema: {
+ *     type: 'object',
+ *     properties: { answer: { type: 'string' } },
+ *     required: ['answer']
+ *   }
+ * };
+ * ```
+ */
+export interface IRResponseFormat {
+  /**
+   * Format type. Currently only JSON Schema-constrained output is supported.
+   */
+  readonly type: 'json_schema';
+
+  /**
+   * JSON Schema the response must conform to.
+   */
+  readonly schema: JSONSchema;
+
+  /**
+   * Hint: reject/retry on schema violation where the backend supports it.
+   */
+  readonly strict?: boolean;
+}
+
 // ============================================================================
 // Request Parameters
 // ============================================================================
@@ -552,6 +593,13 @@ export interface IRCapabilities {
    * Supports tool/function calling.
    */
   readonly tools?: boolean;
+
+  /**
+   * Whether structured/schema-constrained output (`IRChatRequest.responseFormat`)
+   * is enforced natively by the provider's API, or emulated via a
+   * prompt-injection + best-effort JSON extraction fallback.
+   */
+  readonly structuredOutput?: 'native' | 'fallback';
 
   /**
    * Whether the backend can generate embeddings (implements `embed()`).
@@ -863,6 +911,12 @@ export interface IRChatRequest {
    * - { name: string }: Force specific tool
    */
   readonly toolChoice?: 'auto' | 'required' | 'none' | { readonly name: string };
+
+  /**
+   * Structured/schema-constrained output request.
+   * Optional, for JSON-schema-constrained responses.
+   */
+  readonly responseFormat?: IRResponseFormat;
 
   /**
    * Request parameters.

--- a/packages/backend/src/providers/ai21.ts
+++ b/packages/backend/src/providers/ai21.ts
@@ -29,6 +29,9 @@ import {
   buildStaticResult,
   applyModelFilter,
   DEFAULT_AI21_MODELS,
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
   type ModelCapabilityFilter,
 } from '../shared.js';
 import type { ListModelsOptions, ListModelsResult } from 'ai.matey.types';
@@ -124,6 +127,7 @@ export class AI21BackendAdapter implements BackendAdapter<AI21Request, AI21Respo
         streaming: true,
         multiModal: false, // Text-only
         tools: false, // No function calling
+        structuredOutput: 'fallback',
         maxContextTokens: 256000, // Jamba 1.5 has 256K context
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: true,
@@ -146,7 +150,7 @@ export class AI21BackendAdapter implements BackendAdapter<AI21Request, AI21Respo
    */
   public fromIR(request: IRChatRequest): AI21Request {
     const { messages } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -206,7 +210,9 @@ export class AI21BackendAdapter implements BackendAdapter<AI21Request, AI21Respo
 
     const message: IRMessage = {
       role: choice.message.role === 'assistant' ? 'assistant' : 'user',
-      content: choice.message.content,
+      content: originalRequest.responseFormat
+        ? extractStructuredOutputJSON(choice.message.content)
+        : choice.message.content,
     };
 
     const finishReasonMap: Record<string, FinishReason> = {
@@ -234,7 +240,14 @@ export class AI21BackendAdapter implements BackendAdapter<AI21Request, AI21Respo
         custom: {
           ...originalRequest.metadata.custom,
           latencyMs,
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
         },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/anthropic.ts
+++ b/packages/backend/src/providers/anthropic.ts
@@ -98,6 +98,9 @@ export interface AnthropicRequest {
     | { type: 'any' }
     | { type: 'none' }
     | { type: 'tool'; name: string };
+  output_config?: {
+    format: { type: 'json_schema'; schema: Record<string, unknown> };
+  };
 }
 
 /**
@@ -175,6 +178,7 @@ export class AnthropicBackendAdapter implements BackendAdapter<
         streaming: true,
         multiModal: true,
         tools: true,
+        structuredOutput: 'native',
         maxContextTokens: 200000,
         systemMessageStrategy: 'separate-parameter',
         supportsMultipleSystemMessages: false, // Anthropic merges multiple system messages
@@ -595,6 +599,14 @@ export class AnthropicBackendAdapter implements BackendAdapter<
           input_schema: tool.parameters as unknown as Record<string, unknown>,
         })),
         tool_choice: this.convertToolChoice(request.toolChoice),
+        output_config: request.responseFormat
+          ? {
+              format: {
+                type: 'json_schema',
+                schema: request.responseFormat.schema as unknown as Record<string, unknown>,
+              },
+            }
+          : undefined,
       };
 
       return anthropicRequest;
@@ -690,6 +702,7 @@ export class AnthropicBackendAdapter implements BackendAdapter<
             ...originalRequest.metadata.custom,
             anthropicMessageId: response.id,
             latencyMs,
+            ...(originalRequest.responseFormat ? { responseFormatEnforced: true } : {}),
           },
         },
         raw: response as unknown as Record<string, unknown>,

--- a/packages/backend/src/providers/anyscale.ts
+++ b/packages/backend/src/providers/anyscale.ts
@@ -25,6 +25,11 @@ import {
 } from 'ai.matey.errors';
 import { normalizeSystemMessages } from 'ai.matey.utils';
 import { getEffectiveStreamMode, mergeStreamingConfig } from 'ai.matey.utils';
+import {
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+} from '../shared.js';
 
 // ============================================================================
 // Anyscale API Types (OpenAI-compatible)
@@ -113,6 +118,7 @@ export class AnyscaleBackendAdapter implements BackendAdapter<AnyscaleRequest, A
         streaming: true,
         multiModal: false, // Text-only
         tools: false, // No function calling
+        structuredOutput: 'fallback',
         maxContextTokens: 4096, // Llama-2 default
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: true,
@@ -135,7 +141,7 @@ export class AnyscaleBackendAdapter implements BackendAdapter<AnyscaleRequest, A
    */
   public fromIR(request: IRChatRequest): AnyscaleRequest {
     const { messages } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -195,12 +201,16 @@ export class AnyscaleBackendAdapter implements BackendAdapter<AnyscaleRequest, A
       });
     }
 
+    const rawContent =
+      typeof choice.message.content === 'string'
+        ? choice.message.content
+        : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join('');
+
     const message: IRMessage = {
       role: choice.message.role === 'assistant' ? 'assistant' : 'user',
-      content:
-        typeof choice.message.content === 'string'
-          ? choice.message.content
-          : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join(''),
+      content: originalRequest.responseFormat
+        ? extractStructuredOutputJSON(rawContent)
+        : rawContent,
     };
 
     const finishReasonMap: Record<string, FinishReason> = {
@@ -228,7 +238,14 @@ export class AnyscaleBackendAdapter implements BackendAdapter<AnyscaleRequest, A
         custom: {
           ...originalRequest.metadata.custom,
           latencyMs,
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
         },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/aws-bedrock.ts
+++ b/packages/backend/src/providers/aws-bedrock.ts
@@ -25,6 +25,11 @@ import {
 } from 'ai.matey.errors';
 import { normalizeSystemMessages } from 'ai.matey.utils';
 import { getEffectiveStreamMode, mergeStreamingConfig } from 'ai.matey.utils';
+import {
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+} from '../shared.js';
 
 // ============================================================================
 // AWS Bedrock API Types (Converse API)
@@ -142,6 +147,7 @@ export class AWSBedrockBackendAdapter implements BackendAdapter<BedrockRequest, 
         streaming: true, // Note: Not supported in all regions/models
         multiModal: true, // Vision supported in some models
         tools: false, // Converse API doesn't support function calling
+        structuredOutput: 'fallback',
         maxContextTokens: 200000, // Claude 3 models support 200K
         systemMessageStrategy: 'separate-parameter', // Uses system field
         supportsMultipleSystemMessages: true,
@@ -165,7 +171,7 @@ export class AWSBedrockBackendAdapter implements BackendAdapter<BedrockRequest, 
    */
   public fromIR(request: IRChatRequest): BedrockRequest {
     const { messages, systemParameter } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -232,9 +238,13 @@ export class AWSBedrockBackendAdapter implements BackendAdapter<BedrockRequest, 
     originalRequest: IRChatRequest,
     latencyMs: number
   ): IRChatResponse {
+    const rawContent = response.output.message.content.map((c) => c.text).join('');
+
     const message: IRMessage = {
       role: 'assistant',
-      content: response.output.message.content.map((c) => c.text).join(''),
+      content: originalRequest.responseFormat
+        ? extractStructuredOutputJSON(rawContent)
+        : rawContent,
     };
 
     const finishReasonMap: Record<string, FinishReason> = {
@@ -262,7 +272,14 @@ export class AWSBedrockBackendAdapter implements BackendAdapter<BedrockRequest, 
         custom: {
           ...originalRequest.metadata.custom,
           latencyMs: response.metrics?.latencyMs || latencyMs,
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
         },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/azure-openai.ts
+++ b/packages/backend/src/providers/azure-openai.ts
@@ -26,6 +26,11 @@ import {
 } from 'ai.matey.errors';
 import { normalizeSystemMessages } from 'ai.matey.utils';
 import { getEffectiveStreamMode, mergeStreamingConfig } from 'ai.matey.utils';
+import {
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+} from '../shared.js';
 
 // ============================================================================
 // Azure OpenAI API Types (OpenAI-compatible with Azure extensions)
@@ -161,6 +166,7 @@ export class AzureOpenAIBackendAdapter implements BackendAdapter<
         streaming: true,
         multiModal: true, // Vision models available
         tools: true, // Function calling
+        structuredOutput: 'fallback',
         maxContextTokens: 128000,
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: true,
@@ -200,7 +206,7 @@ export class AzureOpenAIBackendAdapter implements BackendAdapter<
    */
   public fromIR(request: IRChatRequest): AzureOpenAIRequest {
     const { messages } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -266,12 +272,16 @@ export class AzureOpenAIBackendAdapter implements BackendAdapter<
       });
     }
 
+    const rawContent =
+      typeof choice.message.content === 'string'
+        ? choice.message.content
+        : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join('');
+
     const message: IRMessage = {
       role: choice.message.role === 'assistant' ? 'assistant' : 'user',
-      content:
-        typeof choice.message.content === 'string'
-          ? choice.message.content
-          : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join(''),
+      content: originalRequest.responseFormat
+        ? extractStructuredOutputJSON(rawContent)
+        : rawContent,
     };
 
     const finishReasonMap: Record<string, FinishReason> = {
@@ -304,7 +314,14 @@ export class AzureOpenAIBackendAdapter implements BackendAdapter<
           ...(choice.content_filter_results
             ? { azure_content_filter: choice.content_filter_results }
             : {}),
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
         },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/cerebras.ts
+++ b/packages/backend/src/providers/cerebras.ts
@@ -25,6 +25,11 @@ import {
 } from 'ai.matey.errors';
 import { normalizeSystemMessages } from 'ai.matey.utils';
 import { getEffectiveStreamMode, mergeStreamingConfig } from 'ai.matey.utils';
+import {
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+} from '../shared.js';
 
 // ============================================================================
 // Cerebras API Types (OpenAI-compatible)
@@ -135,6 +140,7 @@ export class CerebrasBackendAdapter implements BackendAdapter<CerebrasRequest, C
         streaming: true,
         multiModal: false, // Text-only models
         tools: true, // Function calling
+        structuredOutput: 'fallback',
         maxContextTokens: 128000,
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: true,
@@ -157,7 +163,7 @@ export class CerebrasBackendAdapter implements BackendAdapter<CerebrasRequest, C
    */
   public fromIR(request: IRChatRequest): CerebrasRequest {
     const { messages } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -223,12 +229,16 @@ export class CerebrasBackendAdapter implements BackendAdapter<CerebrasRequest, C
       });
     }
 
+    const rawContent =
+      typeof choice.message.content === 'string'
+        ? choice.message.content
+        : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join('');
+
     const message: IRMessage = {
       role: choice.message.role === 'assistant' ? 'assistant' : 'user',
-      content:
-        typeof choice.message.content === 'string'
-          ? choice.message.content
-          : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join(''),
+      content: originalRequest.responseFormat
+        ? extractStructuredOutputJSON(rawContent)
+        : rawContent,
     };
 
     const finishReasonMap: Record<string, FinishReason> = {
@@ -258,7 +268,14 @@ export class CerebrasBackendAdapter implements BackendAdapter<CerebrasRequest, C
           ...originalRequest.metadata.custom,
           latencyMs,
           ...(response.time_info ? { cerebras_timing: response.time_info } : {}),
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
         },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/cloudflare.ts
+++ b/packages/backend/src/providers/cloudflare.ts
@@ -26,6 +26,11 @@ import {
 } from 'ai.matey.errors';
 import { normalizeSystemMessages } from 'ai.matey.utils';
 import { getEffectiveStreamMode, mergeStreamingConfig } from 'ai.matey.utils';
+import {
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+} from '../shared.js';
 
 // ============================================================================
 // Cloudflare Workers AI API Types (OpenAI-compatible)
@@ -148,6 +153,7 @@ export class CloudflareBackendAdapter implements BackendAdapter<
         streaming: true,
         multiModal: true, // Vision models available
         tools: true, // Function calling
+        structuredOutput: 'fallback',
         maxContextTokens: 128000,
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: true,
@@ -171,7 +177,7 @@ export class CloudflareBackendAdapter implements BackendAdapter<
    */
   public fromIR(request: IRChatRequest): CloudflareRequest {
     const { messages } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -231,12 +237,16 @@ export class CloudflareBackendAdapter implements BackendAdapter<
       });
     }
 
+    const rawContent =
+      typeof choice.message.content === 'string'
+        ? choice.message.content
+        : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join('');
+    const content = originalRequest.responseFormat
+      ? extractStructuredOutputJSON(rawContent)
+      : rawContent;
     const message: IRMessage = {
       role: choice.message.role === 'assistant' ? 'assistant' : 'user',
-      content:
-        typeof choice.message.content === 'string'
-          ? choice.message.content
-          : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join(''),
+      content,
     };
 
     const finishReasonMap: Record<string, FinishReason> = {
@@ -265,7 +275,14 @@ export class CloudflareBackendAdapter implements BackendAdapter<
         custom: {
           ...originalRequest.metadata.custom,
           latencyMs,
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
         },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/cohere.ts
+++ b/packages/backend/src/providers/cohere.ts
@@ -34,6 +34,9 @@ import {
   buildStaticResult,
   applyModelFilter,
   DEFAULT_COHERE_MODELS,
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
   type ModelCapabilityFilter,
 } from '../shared.js';
 
@@ -139,6 +142,7 @@ export class CohereBackendAdapter implements BackendAdapter<CohereRequest, Coher
         streaming: true,
         multiModal: false, // Text-only
         tools: false, // No function calling
+        structuredOutput: 'fallback',
         maxContextTokens: 128000,
         systemMessageStrategy: 'separate-parameter', // Uses preamble field
         supportsMultipleSystemMessages: false, // Only one preamble
@@ -161,7 +165,7 @@ export class CohereBackendAdapter implements BackendAdapter<CohereRequest, Coher
    */
   public fromIR(request: IRChatRequest): CohereRequest {
     const { messages, systemParameter } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -247,9 +251,12 @@ export class CohereBackendAdapter implements BackendAdapter<CohereRequest, Coher
     originalRequest: IRChatRequest,
     latencyMs: number
   ): IRChatResponse {
+    const content = originalRequest.responseFormat
+      ? extractStructuredOutputJSON(response.text)
+      : response.text;
     const message: IRMessage = {
       role: 'assistant',
-      content: response.text,
+      content,
     };
 
     const finishReasonMap: Record<string, FinishReason> = {
@@ -283,7 +290,14 @@ export class CohereBackendAdapter implements BackendAdapter<CohereRequest, Coher
           ...(response.citations && response.citations.length > 0
             ? { citations: response.citations }
             : {}),
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
         },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/deepinfra.ts
+++ b/packages/backend/src/providers/deepinfra.ts
@@ -9,7 +9,12 @@
 
 import type { BackendAdapter, BackendAdapterConfig, AdapterMetadata } from 'ai.matey.types';
 import type { IREmbedRequest, IREmbedResponse } from 'ai.matey.types';
-import { executeOpenAICompatibleEmbed } from '../shared.js';
+import {
+  executeOpenAICompatibleEmbed,
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+} from '../shared.js';
 import type {
   IRChatRequest,
   IRChatResponse,
@@ -129,6 +134,7 @@ export class DeepInfraBackendAdapter implements BackendAdapter<
         streaming: true,
         multiModal: true, // Vision models available
         tools: true, // Function calling
+        structuredOutput: 'fallback',
         maxContextTokens: 128000,
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: true,
@@ -151,7 +157,7 @@ export class DeepInfraBackendAdapter implements BackendAdapter<
    */
   public fromIR(request: IRChatRequest): DeepInfraRequest {
     const { messages } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -213,12 +219,16 @@ export class DeepInfraBackendAdapter implements BackendAdapter<
       });
     }
 
+    const rawContent =
+      typeof choice.message.content === 'string'
+        ? choice.message.content
+        : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join('');
+
     const message: IRMessage = {
       role: choice.message.role === 'assistant' ? 'assistant' : 'user',
-      content:
-        typeof choice.message.content === 'string'
-          ? choice.message.content
-          : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join(''),
+      content: originalRequest.responseFormat
+        ? extractStructuredOutputJSON(rawContent)
+        : rawContent,
     };
 
     const finishReasonMap: Record<string, FinishReason> = {
@@ -247,7 +257,14 @@ export class DeepInfraBackendAdapter implements BackendAdapter<
         custom: {
           ...originalRequest.metadata.custom,
           latencyMs,
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
         },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/deepseek.ts
+++ b/packages/backend/src/providers/deepseek.ts
@@ -74,6 +74,7 @@ export class DeepSeekBackendAdapter
         // the API with the V4 generation, 2026)
         multiModal: true,
         tools: true,
+        structuredOutput: 'native',
         maxContextTokens: 1_000_000, // V4 default context window
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: false,

--- a/packages/backend/src/providers/fireworks.ts
+++ b/packages/backend/src/providers/fireworks.ts
@@ -9,7 +9,12 @@
 
 import type { BackendAdapter, BackendAdapterConfig, AdapterMetadata } from 'ai.matey.types';
 import type { IREmbedRequest, IREmbedResponse } from 'ai.matey.types';
-import { executeOpenAICompatibleEmbed } from '../shared.js';
+import {
+  executeOpenAICompatibleEmbed,
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+} from '../shared.js';
 import type {
   IRChatRequest,
   IRChatResponse,
@@ -140,6 +145,7 @@ export class FireworksAIBackendAdapter implements BackendAdapter<
         streaming: true,
         multiModal: true, // Vision models available
         tools: true, // Function calling
+        structuredOutput: 'fallback',
         maxContextTokens: 128000,
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: true,
@@ -162,7 +168,7 @@ export class FireworksAIBackendAdapter implements BackendAdapter<
    */
   public fromIR(request: IRChatRequest): FireworksAIRequest {
     const { messages } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -235,12 +241,16 @@ export class FireworksAIBackendAdapter implements BackendAdapter<
       });
     }
 
+    const rawContent =
+      typeof choice.message.content === 'string'
+        ? choice.message.content
+        : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join('');
+    const content = originalRequest.responseFormat
+      ? extractStructuredOutputJSON(rawContent)
+      : rawContent;
     const message: IRMessage = {
       role: choice.message.role === 'assistant' ? 'assistant' : 'user',
-      content:
-        typeof choice.message.content === 'string'
-          ? choice.message.content
-          : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join(''),
+      content,
     };
 
     const finishReasonMap: Record<string, FinishReason> = {
@@ -268,7 +278,14 @@ export class FireworksAIBackendAdapter implements BackendAdapter<
         custom: {
           ...originalRequest.metadata.custom,
           latencyMs,
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
         },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/gemini.ts
+++ b/packages/backend/src/providers/gemini.ts
@@ -54,6 +54,8 @@ export interface GeminiRequest {
     topK?: number;
     maxOutputTokens?: number;
     stopSequences?: string[];
+    responseMimeType?: string;
+    responseSchema?: Record<string, unknown>;
   };
 }
 
@@ -99,6 +101,7 @@ export class GeminiBackendAdapter implements BackendAdapter<GeminiRequest, Gemin
         streaming: true,
         multiModal: true,
         tools: true,
+        structuredOutput: 'native',
         maxContextTokens: 2000000,
         systemMessageStrategy: 'separate-parameter',
         supportsMultipleSystemMessages: false,
@@ -544,6 +547,10 @@ export class GeminiBackendAdapter implements BackendAdapter<GeminiRequest, Gemin
         stopSequences: request.parameters?.stopSequences
           ? [...request.parameters.stopSequences]
           : undefined,
+        responseMimeType: request.responseFormat ? 'application/json' : undefined,
+        responseSchema: request.responseFormat
+          ? (request.responseFormat.schema as unknown as Record<string, unknown>)
+          : undefined,
       },
     };
   }
@@ -584,7 +591,11 @@ export class GeminiBackendAdapter implements BackendAdapter<GeminiRequest, Gemin
         ...originalRequest.metadata,
         providerResponseId: undefined, // Gemini does not provide a response ID
         provenance: { ...originalRequest.metadata.provenance, backend: this.metadata.name },
-        custom: { ...originalRequest.metadata.custom, latencyMs },
+        custom: {
+          ...originalRequest.metadata.custom,
+          latencyMs,
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: true } : {}),
+        },
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/groq.ts
+++ b/packages/backend/src/providers/groq.ts
@@ -77,6 +77,7 @@ export class GroqBackendAdapter
         streaming: true,
         multiModal: false, // Groq currently focuses on text
         tools: true,
+        structuredOutput: 'native',
         maxContextTokens: 128000, // Varies by model, some support 128K
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: false,

--- a/packages/backend/src/providers/huggingface.ts
+++ b/packages/backend/src/providers/huggingface.ts
@@ -22,6 +22,11 @@ import {
   ErrorCode,
   createErrorFromHttpResponse,
 } from 'ai.matey.errors';
+import {
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+} from '../shared.js';
 
 /**
  * Hugging Face API message format.
@@ -125,6 +130,7 @@ export class HuggingFaceBackendAdapter implements BackendAdapter<
         streaming: false, // Hugging Face Inference API doesn't support streaming in the same way
         multiModal: false, // Text-only for standard inference
         tools: false,
+        structuredOutput: 'fallback',
         maxContextTokens: 4096, // Varies by model
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: false,
@@ -279,7 +285,9 @@ export class HuggingFaceBackendAdapter implements BackendAdapter<
   public fromIR(request: IRChatRequest): HuggingFaceRequest {
     try {
       // Convert messages to prompt text
-      const prompt = this.messagesToPrompt(request.messages);
+      const prompt = this.messagesToPrompt(
+        buildStructuredOutputFallbackMessages(request.messages, request.responseFormat)
+      );
 
       return {
         inputs: prompt,
@@ -334,7 +342,7 @@ export class HuggingFaceBackendAdapter implements BackendAdapter<
 
       const message: IRMessage = {
         role: 'assistant',
-        content: text,
+        content: originalRequest.responseFormat ? extractStructuredOutputJSON(text) : text,
       };
 
       return {
@@ -354,7 +362,14 @@ export class HuggingFaceBackendAdapter implements BackendAdapter<
           custom: {
             ...originalRequest.metadata.custom,
             latencyMs,
+            ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
           },
+          warnings: originalRequest.responseFormat
+            ? [
+                ...(originalRequest.metadata.warnings ?? []),
+                buildResponseFormatFallbackWarning(this.metadata.name),
+              ]
+            : originalRequest.metadata.warnings,
         },
       };
     } catch (error) {

--- a/packages/backend/src/providers/inception.ts
+++ b/packages/backend/src/providers/inception.ts
@@ -76,6 +76,7 @@ export class InceptionBackendAdapter
         streaming: true,
         multiModal: false,
         tools: false,
+        structuredOutput: 'native',
         maxContextTokens: 32768,
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: false,

--- a/packages/backend/src/providers/lmstudio.ts
+++ b/packages/backend/src/providers/lmstudio.ts
@@ -77,6 +77,7 @@ export class LMStudioBackendAdapter
         streaming: true,
         multiModal: false, // Depends on loaded model
         tools: true, // Depends on loaded model
+        structuredOutput: 'native',
         maxContextTokens: 32000, // Varies by loaded model
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: false,

--- a/packages/backend/src/providers/mistral.ts
+++ b/packages/backend/src/providers/mistral.ts
@@ -33,6 +33,9 @@ import {
   buildStaticResult,
   applyModelFilter,
   DEFAULT_MISTRAL_MODELS,
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
   type ModelCapabilityFilter,
 } from '../shared.js';
 import type { ListModelsOptions, ListModelsResult, AIModel } from 'ai.matey.types';
@@ -99,6 +102,7 @@ export class MistralBackendAdapter implements BackendAdapter<MistralRequest, Mis
         streaming: true,
         multiModal: false,
         tools: true,
+        structuredOutput: 'fallback',
         maxContextTokens: 32000,
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: false,
@@ -405,7 +409,7 @@ export class MistralBackendAdapter implements BackendAdapter<MistralRequest, Mis
    */
   public fromIR(request: IRChatRequest): MistralRequest {
     const { messages } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -448,7 +452,10 @@ export class MistralBackendAdapter implements BackendAdapter<MistralRequest, Mis
       });
     }
 
-    const message: IRMessage = { role: 'assistant', content: choice.message.content };
+    const content = originalRequest.responseFormat
+      ? extractStructuredOutputJSON(choice.message.content)
+      : choice.message.content;
+    const message: IRMessage = { role: 'assistant', content };
 
     return {
       message,
@@ -462,7 +469,18 @@ export class MistralBackendAdapter implements BackendAdapter<MistralRequest, Mis
         ...originalRequest.metadata,
         providerResponseId: response.id,
         provenance: { ...originalRequest.metadata.provenance, backend: this.metadata.name },
-        custom: { ...originalRequest.metadata.custom, mistralResponseId: response.id, latencyMs },
+        custom: {
+          ...originalRequest.metadata.custom,
+          mistralResponseId: response.id,
+          latencyMs,
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
+        },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/moonshot.ts
+++ b/packages/backend/src/providers/moonshot.ts
@@ -76,6 +76,7 @@ export class MoonshotBackendAdapter
         streaming: true,
         multiModal: false,
         tools: true,
+        structuredOutput: 'native',
         maxContextTokens: 128000,
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: false,

--- a/packages/backend/src/providers/nvidia.ts
+++ b/packages/backend/src/providers/nvidia.ts
@@ -84,6 +84,7 @@ export class NVIDIABackendAdapter
         streaming: true,
         multiModal: false, // Most NIM models are text-only
         tools: true,
+        structuredOutput: 'native',
         maxContextTokens: 128000, // Varies by model
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: false,

--- a/packages/backend/src/providers/ollama.ts
+++ b/packages/backend/src/providers/ollama.ts
@@ -28,7 +28,14 @@ import {
 } from 'ai.matey.errors';
 import { normalizeSystemMessages } from 'ai.matey.utils';
 import { getEffectiveStreamMode, mergeStreamingConfig } from 'ai.matey.utils';
-import { buildStaticResult, applyModelFilter, type ModelCapabilityFilter } from '../shared.js';
+import {
+  buildStaticResult,
+  applyModelFilter,
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+  type ModelCapabilityFilter,
+} from '../shared.js';
 
 // ============================================================================
 // Ollama API Types
@@ -83,6 +90,7 @@ export class OllamaBackendAdapter implements BackendAdapter<OllamaRequest, Ollam
         streaming: true,
         multiModal: false,
         tools: false,
+        structuredOutput: 'fallback',
         embeddings: true,
         maxContextTokens: 4096, // Varies by model
         systemMessageStrategy: 'in-messages',
@@ -325,7 +333,7 @@ export class OllamaBackendAdapter implements BackendAdapter<OllamaRequest, Ollam
    */
   public fromIR(request: IRChatRequest): OllamaRequest {
     const { messages } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -362,7 +370,10 @@ export class OllamaBackendAdapter implements BackendAdapter<OllamaRequest, Ollam
     originalRequest: IRChatRequest,
     latencyMs: number
   ): IRChatResponse {
-    const message: IRMessage = { role: 'assistant', content: response.message.content };
+    const content = originalRequest.responseFormat
+      ? extractStructuredOutputJSON(response.message.content)
+      : response.message.content;
+    const message: IRMessage = { role: 'assistant', content };
 
     return {
       message,
@@ -379,7 +390,17 @@ export class OllamaBackendAdapter implements BackendAdapter<OllamaRequest, Ollam
         ...originalRequest.metadata,
         providerResponseId: undefined, // Ollama does not provide a response ID
         provenance: { ...originalRequest.metadata.provenance, backend: this.metadata.name },
-        custom: { ...originalRequest.metadata.custom, latencyMs },
+        custom: {
+          ...originalRequest.metadata.custom,
+          latencyMs,
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
+        },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/openai.ts
+++ b/packages/backend/src/providers/openai.ts
@@ -101,6 +101,10 @@ export interface OpenAIRequest {
     };
   }>;
   tool_choice?: 'auto' | 'none' | 'required' | { type: 'function'; function: { name: string } };
+  response_format?: {
+    type: 'json_schema';
+    json_schema: { name: string; schema: Record<string, unknown>; strict?: boolean };
+  };
 }
 
 /**
@@ -207,6 +211,7 @@ export class OpenAIBackendAdapter implements BackendAdapter<OpenAIRequest, OpenA
         streaming: true,
         multiModal: true,
         tools: true,
+        structuredOutput: 'native',
         embeddings: true,
         embeddingModels: ['text-embedding-3-small', 'text-embedding-3-large'],
         maxEmbeddingBatchSize: 2048,
@@ -725,6 +730,16 @@ export class OpenAIBackendAdapter implements BackendAdapter<OpenAIRequest, OpenA
           },
         })),
         tool_choice: this.convertToolChoice(request.toolChoice),
+        response_format: request.responseFormat
+          ? {
+              type: 'json_schema',
+              json_schema: {
+                name: 'response',
+                schema: request.responseFormat.schema as unknown as Record<string, unknown>,
+                strict: request.responseFormat.strict,
+              },
+            }
+          : undefined,
       };
 
       return openaiRequest;
@@ -804,6 +819,7 @@ export class OpenAIBackendAdapter implements BackendAdapter<OpenAIRequest, OpenA
             ...originalRequest.metadata.custom,
             openaiResponseId: response.id,
             latencyMs,
+            ...(originalRequest.responseFormat ? { responseFormatEnforced: true } : {}),
           },
         },
         raw: response as unknown as Record<string, unknown>,

--- a/packages/backend/src/providers/openrouter.ts
+++ b/packages/backend/src/providers/openrouter.ts
@@ -25,6 +25,11 @@ import {
 } from 'ai.matey.errors';
 import { normalizeSystemMessages } from 'ai.matey.utils';
 import { getEffectiveStreamMode, mergeStreamingConfig } from 'ai.matey.utils';
+import {
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+} from '../shared.js';
 
 // ============================================================================
 // OpenRouter API Types (OpenAI-compatible with extensions)
@@ -146,6 +151,7 @@ export class OpenRouterBackendAdapter implements BackendAdapter<
         streaming: true,
         multiModal: true, // Vision models available
         tools: true, // Function calling
+        structuredOutput: 'fallback',
         maxContextTokens: 128000,
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: true,
@@ -170,7 +176,7 @@ export class OpenRouterBackendAdapter implements BackendAdapter<
    */
   public fromIR(request: IRChatRequest): OpenRouterRequest {
     const { messages } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -248,12 +254,16 @@ export class OpenRouterBackendAdapter implements BackendAdapter<
       });
     }
 
+    const rawContent =
+      typeof choice.message.content === 'string'
+        ? choice.message.content
+        : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join('');
+
     const message: IRMessage = {
       role: choice.message.role === 'assistant' ? 'assistant' : 'user',
-      content:
-        typeof choice.message.content === 'string'
-          ? choice.message.content
-          : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join(''),
+      content: originalRequest.responseFormat
+        ? extractStructuredOutputJSON(rawContent)
+        : rawContent,
     };
 
     const finishReasonMap: Record<string, FinishReason> = {
@@ -284,7 +294,14 @@ export class OpenRouterBackendAdapter implements BackendAdapter<
           ...originalRequest.metadata.custom,
           latencyMs,
           actualModel: response.model, // OpenRouter may route to different model
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
         },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/perplexity.ts
+++ b/packages/backend/src/providers/perplexity.ts
@@ -25,6 +25,11 @@ import {
 } from 'ai.matey.errors';
 import { normalizeSystemMessages } from 'ai.matey.utils';
 import { getEffectiveStreamMode, mergeStreamingConfig } from 'ai.matey.utils';
+import {
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+} from '../shared.js';
 
 // ============================================================================
 // Perplexity AI API Types (OpenAI-compatible with search extensions)
@@ -123,6 +128,7 @@ export class PerplexityBackendAdapter implements BackendAdapter<
         streaming: true,
         multiModal: false, // Text-only
         tools: false, // No function calling
+        structuredOutput: 'fallback',
         maxContextTokens: 128000,
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: true,
@@ -145,7 +151,7 @@ export class PerplexityBackendAdapter implements BackendAdapter<
    */
   public fromIR(request: IRChatRequest): PerplexityRequest {
     const { messages } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -225,12 +231,17 @@ export class PerplexityBackendAdapter implements BackendAdapter<
       });
     }
 
+    const rawContent =
+      typeof choice.message.content === 'string'
+        ? choice.message.content
+        : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join('');
+    const content = originalRequest.responseFormat
+      ? extractStructuredOutputJSON(rawContent)
+      : rawContent;
+
     const message: IRMessage = {
       role: choice.message.role === 'assistant' ? 'assistant' : 'user',
-      content:
-        typeof choice.message.content === 'string'
-          ? choice.message.content
-          : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join(''),
+      content,
     };
 
     const finishReasonMap: Record<string, FinishReason> = {
@@ -261,7 +272,14 @@ export class PerplexityBackendAdapter implements BackendAdapter<
           ...(response.citations && response.citations.length > 0
             ? { citations: response.citations }
             : {}),
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
         },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/replicate.ts
+++ b/packages/backend/src/providers/replicate.ts
@@ -25,6 +25,11 @@ import {
 } from 'ai.matey.errors';
 import { normalizeSystemMessages } from 'ai.matey.utils';
 import { getEffectiveStreamMode, mergeStreamingConfig } from 'ai.matey.utils';
+import {
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+} from '../shared.js';
 
 // ============================================================================
 // Replicate API Types (Predictions API)
@@ -100,6 +105,7 @@ export class ReplicateBackendAdapter implements BackendAdapter<
         streaming: true, // Limited streaming support
         multiModal: false, // Varies by model
         tools: false, // No function calling
+        structuredOutput: 'fallback',
         maxContextTokens: 4096, // Varies by model
         systemMessageStrategy: 'separate-parameter', // Uses system_prompt
         supportsMultipleSystemMessages: false,
@@ -122,7 +128,7 @@ export class ReplicateBackendAdapter implements BackendAdapter<
    */
   public fromIR(request: IRChatRequest): ReplicateRequest {
     const { messages, systemParameter } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -180,6 +186,10 @@ export class ReplicateBackendAdapter implements BackendAdapter<
       content = prediction.output.join('');
     }
 
+    if (originalRequest.responseFormat) {
+      content = extractStructuredOutputJSON(content);
+    }
+
     const message: IRMessage = {
       role: 'assistant',
       content,
@@ -207,7 +217,14 @@ export class ReplicateBackendAdapter implements BackendAdapter<
           latencyMs: prediction.metrics?.predict_time
             ? prediction.metrics.predict_time * 1000
             : latencyMs,
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
         },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: prediction as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/sambanova.ts
+++ b/packages/backend/src/providers/sambanova.ts
@@ -77,6 +77,7 @@ export class SambaNovaBackendAdapter
         streaming: true,
         multiModal: false,
         tools: true,
+        structuredOutput: 'native',
         maxContextTokens: 131072,
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: false,

--- a/packages/backend/src/providers/together-ai.ts
+++ b/packages/backend/src/providers/together-ai.ts
@@ -9,7 +9,12 @@
 
 import type { BackendAdapter, BackendAdapterConfig, AdapterMetadata } from 'ai.matey.types';
 import type { IREmbedRequest, IREmbedResponse } from 'ai.matey.types';
-import { executeOpenAICompatibleEmbed } from '../shared.js';
+import {
+  executeOpenAICompatibleEmbed,
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+} from '../shared.js';
 import type {
   IRChatRequest,
   IRChatResponse,
@@ -129,6 +134,7 @@ export class TogetherAIBackendAdapter implements BackendAdapter<
         streaming: true,
         multiModal: true, // Vision models available
         tools: true, // Function calling
+        structuredOutput: 'fallback',
         maxContextTokens: 128000,
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: true,
@@ -151,7 +157,7 @@ export class TogetherAIBackendAdapter implements BackendAdapter<
    */
   public fromIR(request: IRChatRequest): TogetherAIRequest {
     const { messages } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -213,12 +219,16 @@ export class TogetherAIBackendAdapter implements BackendAdapter<
       });
     }
 
+    const rawContent =
+      typeof choice.message.content === 'string'
+        ? choice.message.content
+        : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join('');
+    const content = originalRequest.responseFormat
+      ? extractStructuredOutputJSON(rawContent)
+      : rawContent;
     const message: IRMessage = {
       role: choice.message.role === 'assistant' ? 'assistant' : 'user',
-      content:
-        typeof choice.message.content === 'string'
-          ? choice.message.content
-          : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join(''),
+      content,
     };
 
     const finishReasonMap: Record<string, FinishReason> = {
@@ -247,7 +257,14 @@ export class TogetherAIBackendAdapter implements BackendAdapter<
         custom: {
           ...originalRequest.metadata.custom,
           latencyMs,
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
         },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/providers/xai.ts
+++ b/packages/backend/src/providers/xai.ts
@@ -25,6 +25,11 @@ import {
 } from 'ai.matey.errors';
 import { normalizeSystemMessages } from 'ai.matey.utils';
 import { getEffectiveStreamMode, mergeStreamingConfig } from 'ai.matey.utils';
+import {
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+} from '../shared.js';
 
 // ============================================================================
 // xAI API Types (OpenAI-compatible)
@@ -123,6 +128,7 @@ export class XAIBackendAdapter implements BackendAdapter<XAIRequest, XAIResponse
         streaming: true,
         multiModal: true, // Grok-vision available
         tools: true, // Function calling
+        structuredOutput: 'fallback',
         maxContextTokens: 2_000_000, // 2M context window
         systemMessageStrategy: 'in-messages',
         supportsMultipleSystemMessages: true,
@@ -145,7 +151,7 @@ export class XAIBackendAdapter implements BackendAdapter<XAIRequest, XAIResponse
    */
   public fromIR(request: IRChatRequest): XAIRequest {
     const { messages } = normalizeSystemMessages(
-      request.messages,
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
       this.metadata.capabilities.systemMessageStrategy,
       this.metadata.capabilities.supportsMultipleSystemMessages
     );
@@ -204,12 +210,17 @@ export class XAIBackendAdapter implements BackendAdapter<XAIRequest, XAIResponse
       });
     }
 
+    const rawContent =
+      typeof choice.message.content === 'string'
+        ? choice.message.content
+        : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join('');
+    const content = originalRequest.responseFormat
+      ? extractStructuredOutputJSON(rawContent)
+      : rawContent;
+
     const message: IRMessage = {
       role: choice.message.role === 'assistant' ? 'assistant' : 'user',
-      content:
-        typeof choice.message.content === 'string'
-          ? choice.message.content
-          : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join(''),
+      content,
     };
 
     const finishReasonMap: Record<string, FinishReason> = {
@@ -238,7 +249,14 @@ export class XAIBackendAdapter implements BackendAdapter<XAIRequest, XAIResponse
         custom: {
           ...originalRequest.metadata.custom,
           latencyMs,
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
         },
+        warnings: originalRequest.responseFormat
+          ? [
+              ...(originalRequest.metadata.warnings ?? []),
+              buildResponseFormatFallbackWarning(this.metadata.name),
+            ]
+          : originalRequest.metadata.warnings,
       },
       raw: response as unknown as Record<string, unknown>,
     };

--- a/packages/backend/src/shared.ts
+++ b/packages/backend/src/shared.ts
@@ -12,6 +12,8 @@ import type {
   IRMessage,
   IREmbedRequest,
   IREmbedResponse,
+  IRResponseFormat,
+  IRWarning,
   AIModel,
   ListModelsResult,
 } from 'ai.matey.types';
@@ -376,6 +378,113 @@ export function safeParseJSON(text: string | undefined | null): Record<string, u
   } catch {
     return {};
   }
+}
+
+// ============================================================================
+// Structured Output Fallback
+// ============================================================================
+//
+// For backends with no native schema-constrained output mechanism, we emulate
+// `IRChatRequest.responseFormat` by appending a schema instruction to the
+// prompt and doing a best-effort, local (no network retry) extraction/repair
+// of JSON from the plain-text reply. Callers should still validate the
+// parsed result against their schema - this is best-effort, not a guarantee.
+
+/**
+ * Append a schema-instruction message for backends with no native
+ * structured-output mechanism. Returns `messages` unchanged if no
+ * `responseFormat` was requested.
+ */
+export function buildStructuredOutputFallbackMessages(
+  messages: readonly IRMessage[],
+  responseFormat: IRResponseFormat | undefined
+): readonly IRMessage[] {
+  if (!responseFormat) {
+    return messages;
+  }
+
+  const instruction: IRMessage = {
+    role: 'system',
+    content:
+      'Respond with ONLY valid JSON matching this JSON Schema - no prose, no markdown code ' +
+      `fences, no explanation before or after the JSON:\n${JSON.stringify(responseFormat.schema)}`,
+  };
+
+  return [...messages, instruction];
+}
+
+/**
+ * Best-effort extraction of a JSON value from a (possibly prose-wrapped)
+ * model response, for backends emulating `responseFormat` via prompt
+ * injection. Strips markdown code fences, locates the outermost balanced
+ * `{...}`/`[...]` span, and tries one repair pass (removing trailing commas)
+ * if the initial parse fails.
+ *
+ * Returns the cleaned JSON text if it parses successfully, otherwise
+ * returns `text` unchanged - the caller is responsible for validating
+ * whatever comes back.
+ */
+export function extractStructuredOutputJSON(text: string): string {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+  const candidate = (fenced?.[1] ?? text).trim();
+
+  const span = extractBalancedJSONSpan(candidate);
+  if (!span) {
+    return text;
+  }
+
+  if (isValidJSON(span)) {
+    return span;
+  }
+
+  const repaired = span.replace(/,(\s*[}\]])/g, '$1');
+  return isValidJSON(repaired) ? repaired : text;
+}
+
+function extractBalancedJSONSpan(text: string): string | undefined {
+  const start = text.search(/[{[]/);
+  if (start === -1) {
+    return undefined;
+  }
+
+  const open = text[start];
+  const close = open === '{' ? '}' : ']';
+  let depth = 0;
+
+  for (let i = start; i < text.length; i++) {
+    if (text[i] === open) {
+      depth++;
+    } else if (text[i] === close) {
+      depth--;
+      if (depth === 0) {
+        return text.slice(start, i + 1);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function isValidJSON(text: string): boolean {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build the semantic-drift warning for a fallback (non-native)
+ * structured-output response, per the IR's warning-tracking convention.
+ */
+export function buildResponseFormatFallbackWarning(backendName: string): IRWarning {
+  return {
+    category: 'capability-unsupported',
+    severity: 'info',
+    message: `${backendName} has no native structured-output mechanism; responseFormat was emulated via prompt injection and best-effort JSON extraction.`,
+    field: 'responseFormat',
+  };
 }
 
 // ============================================================================

--- a/tests/unit/backend-response-format.test.ts
+++ b/tests/unit/backend-response-format.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Structured/schema-constrained output (`responseFormat`) mapping tests.
+ *
+ * Verifies that native backends (OpenAI, Anthropic, Gemini, Groq) map
+ * `IRChatRequest.responseFormat` onto their own provider mechanism, and that
+ * fallback backends (Mistral, Ollama, Cohere) emulate it via prompt injection
+ * plus best-effort JSON extraction - in both cases setting
+ * `metadata.custom.responseFormatEnforced` appropriately.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  OpenAIBackendAdapter,
+  AnthropicBackendAdapter,
+  GeminiBackendAdapter,
+  GroqBackendAdapter,
+  MistralBackendAdapter,
+  OllamaBackendAdapter,
+  CohereBackendAdapter,
+} from 'ai.matey.backend';
+import type { IRChatRequest, IRResponseFormat } from 'ai.matey.types';
+
+const FLAT_SCHEMA: IRResponseFormat = {
+  type: 'json_schema',
+  schema: {
+    type: 'object',
+    properties: { answer: { type: 'string' } },
+    required: ['answer'],
+  },
+};
+
+// A non-trivial discriminated-union schema, in the spirit of PTM's
+// PROPOSAL_JSON_SCHEMA (a tagged union over multiple action "kinds").
+const PROPOSAL_SCHEMA: IRResponseFormat = {
+  type: 'json_schema',
+  schema: {
+    type: 'object',
+    properties: {
+      kind: { type: 'string', enum: ['click', 'type', 'wait', 'done'] },
+      target: { type: 'string' },
+      value: { type: 'string' },
+      reason: { type: 'string' },
+    },
+    required: ['kind', 'reason'],
+  },
+  strict: true,
+};
+
+function makeRequest(overrides: Partial<IRChatRequest> = {}): IRChatRequest {
+  return {
+    messages: [{ role: 'user', content: 'Extract the answer.' }],
+    parameters: { model: 'test-model' },
+    metadata: { requestId: 'req-1', timestamp: Date.now(), provenance: {} },
+    ...overrides,
+  };
+}
+
+describe('OpenAI backend responseFormat mapping (native)', () => {
+  const adapter = new OpenAIBackendAdapter({ apiKey: 'test-key' });
+
+  it('maps responseFormat to response_format.json_schema', () => {
+    const req = adapter.fromIR(makeRequest({ responseFormat: FLAT_SCHEMA }));
+    expect(req.response_format).toEqual({
+      type: 'json_schema',
+      json_schema: { name: 'response', schema: FLAT_SCHEMA.schema, strict: undefined },
+    });
+  });
+
+  it('maps a discriminated-union schema with strict:true', () => {
+    const req = adapter.fromIR(makeRequest({ responseFormat: PROPOSAL_SCHEMA }));
+    expect(req.response_format?.json_schema.schema).toEqual(PROPOSAL_SCHEMA.schema);
+    expect(req.response_format?.json_schema.strict).toBe(true);
+  });
+
+  it('omits response_format when no responseFormat is requested', () => {
+    const req = adapter.fromIR(makeRequest());
+    expect(req.response_format).toBeUndefined();
+  });
+
+  it('sets responseFormatEnforced: true in toIR when responseFormat was requested', () => {
+    const response = adapter.toIR(
+      {
+        id: 'resp_1',
+        object: 'chat.completion',
+        created: 0,
+        model: 'test-model',
+        choices: [
+          { index: 0, message: { role: 'assistant', content: '{"answer":"42"}' }, finish_reason: 'stop' },
+        ],
+      },
+      makeRequest({ responseFormat: FLAT_SCHEMA }),
+      10
+    );
+    expect(response.metadata.custom?.responseFormatEnforced).toBe(true);
+  });
+
+  it('omits responseFormatEnforced when no responseFormat was requested', () => {
+    const response = adapter.toIR(
+      {
+        id: 'resp_1',
+        object: 'chat.completion',
+        created: 0,
+        model: 'test-model',
+        choices: [{ index: 0, message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+      },
+      makeRequest(),
+      10
+    );
+    expect(response.metadata.custom?.responseFormatEnforced).toBeUndefined();
+  });
+});
+
+describe('Anthropic backend responseFormat mapping (native)', () => {
+  const adapter = new AnthropicBackendAdapter({ apiKey: 'test-key' });
+
+  it('maps responseFormat to output_config.format', () => {
+    const req = adapter.fromIR(makeRequest({ responseFormat: FLAT_SCHEMA }));
+    expect(req.output_config).toEqual({
+      format: { type: 'json_schema', schema: FLAT_SCHEMA.schema },
+    });
+  });
+
+  it('omits output_config when no responseFormat is requested', () => {
+    const req = adapter.fromIR(makeRequest());
+    expect(req.output_config).toBeUndefined();
+  });
+});
+
+describe('Gemini backend responseFormat mapping (native)', () => {
+  const adapter = new GeminiBackendAdapter({ apiKey: 'test-key' });
+
+  it('maps responseFormat to generationConfig.responseSchema', () => {
+    const req = adapter.fromIR(makeRequest({ responseFormat: FLAT_SCHEMA }));
+    expect(req.generationConfig?.responseMimeType).toBe('application/json');
+    expect(req.generationConfig?.responseSchema).toEqual(FLAT_SCHEMA.schema);
+  });
+
+  it('omits responseSchema when no responseFormat is requested', () => {
+    const req = adapter.fromIR(makeRequest());
+    expect(req.generationConfig?.responseMimeType).toBeUndefined();
+    expect(req.generationConfig?.responseSchema).toBeUndefined();
+  });
+});
+
+describe('Groq backend responseFormat mapping (inherited native)', () => {
+  const adapter = new GroqBackendAdapter({ apiKey: 'test-key' });
+
+  it('advertises native structuredOutput support', () => {
+    expect(adapter.metadata.capabilities.structuredOutput).toBe('native');
+  });
+
+  it('maps responseFormat via the inherited OpenAI fromIR', () => {
+    const req = adapter.fromIR(makeRequest({ responseFormat: FLAT_SCHEMA }));
+    expect(req.response_format?.json_schema.schema).toEqual(FLAT_SCHEMA.schema);
+  });
+});
+
+describe('Mistral backend responseFormat fallback', () => {
+  const adapter = new MistralBackendAdapter({ apiKey: 'test-key' });
+
+  it('advertises fallback structuredOutput support', () => {
+    expect(adapter.metadata.capabilities.structuredOutput).toBe('fallback');
+  });
+
+  it('folds a schema-instruction message into the combined system message', () => {
+    // Mistral's 'in-messages' + supportsMultipleSystemMessages:false strategy
+    // combines all system-role messages (including the appended fallback
+    // instruction) into a single leading system message.
+    const req = adapter.fromIR(makeRequest({ responseFormat: FLAT_SCHEMA }));
+    expect(req.messages).toHaveLength(2);
+    expect(req.messages[0]?.role).toBe('system');
+    expect(req.messages[0]?.content).toContain(JSON.stringify(FLAT_SCHEMA.schema));
+    expect(req.messages[1]?.role).toBe('user');
+  });
+
+  it('does not append an instruction message when responseFormat is absent', () => {
+    const req = adapter.fromIR(makeRequest());
+    expect(req.messages).toHaveLength(1);
+  });
+
+  it('extracts JSON from a prose-wrapped reply and marks responseFormatEnforced: false', () => {
+    const response = adapter.toIR(
+      {
+        id: 'resp_1',
+        object: 'chat.completion',
+        created: 0,
+        model: 'test-model',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: 'Sure, here you go:\n```json\n{"answer": "42"}\n```\nHope that helps!',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+      makeRequest({ responseFormat: FLAT_SCHEMA }),
+      10
+    );
+
+    expect(response.message.content).toBe('{"answer": "42"}');
+    expect(response.metadata.custom?.responseFormatEnforced).toBe(false);
+    expect(response.metadata.warnings).toEqual([
+      expect.objectContaining({ category: 'capability-unsupported', field: 'responseFormat' }),
+    ]);
+  });
+
+  it('repairs trailing commas in an extracted JSON span', () => {
+    const response = adapter.toIR(
+      {
+        id: 'resp_1',
+        object: 'chat.completion',
+        created: 0,
+        model: 'test-model',
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: '{"kind": "done", "reason": "ok",}' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+      makeRequest({ responseFormat: PROPOSAL_SCHEMA }),
+      10
+    );
+
+    expect(() => JSON.parse(response.message.content as string)).not.toThrow();
+    expect(JSON.parse(response.message.content as string)).toEqual({ kind: 'done', reason: 'ok' });
+  });
+
+  it('leaves content untouched when no responseFormat was requested', () => {
+    const response = adapter.toIR(
+      {
+        id: 'resp_1',
+        object: 'chat.completion',
+        created: 0,
+        model: 'test-model',
+        choices: [{ index: 0, message: { role: 'assistant', content: 'plain text reply' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+      makeRequest(),
+      10
+    );
+
+    expect(response.message.content).toBe('plain text reply');
+    expect(response.metadata.custom?.responseFormatEnforced).toBeUndefined();
+    expect(response.metadata.warnings).toBeUndefined();
+  });
+});
+
+describe('Ollama backend responseFormat fallback', () => {
+  const adapter = new OllamaBackendAdapter({});
+
+  it('advertises fallback structuredOutput support', () => {
+    expect(adapter.metadata.capabilities.structuredOutput).toBe('fallback');
+  });
+
+  it('appends a schema-instruction message and extracts JSON on the way back', () => {
+    const req = adapter.fromIR(makeRequest({ responseFormat: PROPOSAL_SCHEMA }));
+    expect(req.messages[0]?.role).toBe('system');
+    expect(req.messages[0]?.content).toContain(JSON.stringify(PROPOSAL_SCHEMA.schema));
+
+    const response = adapter.toIR(
+      {
+        model: 'test-model',
+        created_at: 'now',
+        message: { role: 'assistant', content: '{"kind": "wait", "reason": "loading"}' },
+        done: true,
+      },
+      makeRequest({ responseFormat: PROPOSAL_SCHEMA }),
+      10
+    );
+
+    expect(response.message.content).toBe('{"kind": "wait", "reason": "loading"}');
+    expect(response.metadata.custom?.responseFormatEnforced).toBe(false);
+  });
+});
+
+describe('Cohere backend responseFormat fallback', () => {
+  const adapter = new CohereBackendAdapter({ apiKey: 'test-key' });
+
+  it('advertises fallback structuredOutput support', () => {
+    expect(adapter.metadata.capabilities.structuredOutput).toBe('fallback');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `IRChatRequest.responseFormat` (JSON-schema-constrained output), reusing the existing `JSONSchema` type
- Native mapping for OpenAI, Anthropic, Gemini + their OpenAI-compatible inheritors (Groq, DeepSeek, Inception, Moonshot, NVIDIA, LM Studio, SambaNova)
- Prompt-injection + best-effort JSON extraction/repair fallback for the remaining 17 backends, with a `capability-unsupported` `IRWarning`
- `IRCapabilities.structuredOutput` and `response.metadata.custom.responseFormatEnforced` let callers tell native from fallback
- Docs (`docs/IR-FORMAT.md`), changeset, and 20 new tests

Closes #16.

## Test plan
- [x] `npm run build` (all 23 workspace packages)
- [x] `npm test` (full suite: 1408 passed, 11 pre-existing skips, 0 failures)
- [x] `npm run lint` (0 errors)
- [x] New tests in `tests/unit/backend-response-format.test.ts` cover native mapping (OpenAI/Anthropic/Gemini/Groq) and fallback behavior (Mistral/Ollama/Cohere), including a discriminated-union schema and trailing-comma repair

## Note
While implementing this, found an unrelated pre-existing bug: 11 adapters advertise `capabilities.tools: true` but never map `request.tools`/`toolChoice`. Filed separately as #17 rather than fixing inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)