### PR TITLE
Fix broken CJS entry points across the package family

### DIFF
--- a/.changeset/cjs-package-json-marker.md
+++ b/.changeset/cjs-package-json-marker.md
@@ -1,0 +1,37 @@
+---
+'ai.matey': patch
+'ai.matey.backend': patch
+'ai.matey.backend.browser': patch
+'ai.matey.cli': patch
+'ai.matey.core': patch
+'ai.matey.errors': patch
+'ai.matey.frontend': patch
+'ai.matey.http': patch
+'ai.matey.http.core': patch
+'ai.matey.middleware': patch
+'ai.matey.native.apple': patch
+'ai.matey.native.model-runner': patch
+'ai.matey.native.node-llamacpp': patch
+'ai.matey.patterns': patch
+'ai.matey.react.core': patch
+'ai.matey.react.hooks': patch
+'ai.matey.react.nextjs': patch
+'ai.matey.react.stream': patch
+'ai.matey.testing': patch
+'ai.matey.types': patch
+'ai.matey.utils': patch
+'ai.matey.wrapper': patch
+---
+
+Fix broken CJS entry points across the whole package family. Every package declares
+`"type": "module"` for ESM subpath resolution, but shipped `dist/cjs/` builds with no nested
+override - Node walked up to the package root, saw `"type": "module"`, and misinterpreted the
+compiled CommonJS as ESM, so `require("ai.matey.x")` failed with `Cannot find module './y.js'`
+on every package in the family (ESM `import` was unaffected). Each package's build now emits a
+`dist/cjs/package.json` containing `{"type":"commonjs"}` (via a new
+`scripts/fix-cjs-package-json.js` post-build step) to correctly scope the CJS build's module
+type. No source or `exports` map changes - verified via `npm pack` + fresh install against the
+exact repro in #23, both direct `require()` and the `require` export condition on subpaths (e.g.
+`ai.matey.backend.browser/chrome-ai`).
+
+(#23)

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "turbo run build",
+    "build": "turbo run build && node scripts/fix-cjs-package-json.js",
     "build:esm": "turbo run build:esm",
-    "build:cjs": "turbo run build:cjs",
+    "build:cjs": "turbo run build:cjs && node scripts/fix-cjs-package-json.js",
     "build:types": "turbo run build:types",
     "clean": "turbo run clean && rm -rf node_modules/.cache",
     "typecheck": "turbo run typecheck",

--- a/scripts/fix-cjs-package-json.js
+++ b/scripts/fix-cjs-package-json.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+/**
+ * Write a `dist/cjs/package.json` marker ({"type":"commonjs"}) into every
+ * workspace package's CJS build output.
+ *
+ * Every package's own package.json declares "type": "module" (so ESM
+ * subpath imports resolve correctly), but each also ships a dist/cjs/ build
+ * compiled to CommonJS for the `require` export condition. Without a nested
+ * dist/cjs/package.json overriding the type, Node walks up to the nearest
+ * package.json, finds "type": "module", and treats the compiled CJS files
+ * as ES modules - so `require("ai.matey.x")` fails with
+ * "Cannot find module './y.js'" (the compiled `require("./y.js")` call is
+ * interpreted as an ESM import, which resolves differently). See #23.
+ *
+ * Safe to run repeatedly; run after `turbo run build`/`build:cjs`.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packagesDir = path.join(__dirname, '..', 'packages');
+
+function main() {
+  const packages = fs
+    .readdirSync(packagesDir)
+    .filter((entry) => fs.statSync(path.join(packagesDir, entry)).isDirectory());
+
+  let written = 0;
+
+  for (const pkg of packages) {
+    const cjsDir = path.join(packagesDir, pkg, 'dist', 'cjs');
+    if (!fs.existsSync(cjsDir)) {
+      continue;
+    }
+
+    const markerPath = path.join(cjsDir, 'package.json');
+    fs.writeFileSync(markerPath, JSON.stringify({ type: 'commonjs' }, null, 2) + '\n');
+    written++;
+  }
+
+  console.log(`Wrote dist/cjs/package.json marker to ${written} package(s).`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- Every package declares `"type": "module"` (needed for ESM subpath resolution) but ships a `dist/cjs/` build compiled to CommonJS with no nested override - Node walks up to the package root, sees `"type": "module"`, and misinterprets the compiled CJS as ESM. `require("ai.matey.x")` failed with `Cannot find module './y.js'` on every published package in the family; ESM `import` was unaffected.
- Adds `scripts/fix-cjs-package-json.js`, wired into the root `build`/`build:cjs` npm scripts, writing `dist/cjs/package.json` (`{"type":"commonjs"}`) into every package's CJS output after each build - a single, low-touch fix (Option 1 from the issue) with no source or `exports` map changes needed anywhere.

Closes #23.

## Verification
- `npm run build` (fresh, all 23 workspace packages) then confirmed `dist/cjs/package.json` is written to all 22 CJS-building packages
- Full test suite: 1455 passed, 11 pre-existing skips, 0 failures
- Lint: 0 errors
- **End-to-end repro test** (matches the issue's exact repro): `npm pack` on `ai.matey.types`, `ai.matey.errors`, `ai.matey.utils`, `ai.matey.backend.browser` from the fixed working tree, installed into a scratch project, then:
  - `require('ai.matey.backend.browser')` → works
  - `require('ai.matey.backend.browser/chrome-ai')` → works (the exact subpath from the issue)
  - Confirmed the bug still reproduces against the *currently-published* `ai.matey.types@0.5.0` on npm when only `ai.matey.backend.browser` is packed locally (validates the issue's "whole dependency chain" claim) - so this needs to ship as a coordinated patch across all 22 affected packages, which the changeset does

🤖 Generated with [Claude Code](https://claude.com/claude-code)