### PR TITLE
Add ai.matey.mcp: MCP tool-calling via an injectable client

### DIFF
--- a/.changeset/mcp-package.md
+++ b/.changeset/mcp-package.md
@@ -1,0 +1,20 @@
+---
+'ai.matey.mcp': minor
+---
+
+New package: `ai.matey.mcp` - MCP (Model Context Protocol) tool-calling for AI Matey.
+
+Translates MCP tools into the `ToolDefinition` shape consumed by `ai.matey.core`'s
+`Bridge.runTools()` agentic loop, via an injectable `McpClientLike` client - no hard (or peer)
+dependency on any MCP SDK. Any client satisfying the small structural interface (`listTools`,
+`callTool`) works: the official `@modelcontextprotocol/sdk` wrapped by hand,
+[`mcp-query`](https://github.com/johnhenry/mcp-query) (`@johnhenry/mcpq`), or a test fake.
+Also compatible with WebMCP-exposed tools via `mcp-query`'s `webMcpToolServer()` shim, with no
+changes needed on either side.
+
+Exports: `McpClientLike`/`McpToolSchema`/`McpCallToolResult` (structural types),
+`mcpToolToIRTool`/`extractMcpResultText` (pure MCP↔IR conversion), `mcpToolsToDefinitions`
+(MCP tools → `Record<string, ToolDefinition>`), and `runMcpTools` (a convenience wrapper composing
+`mcpToolsToDefinitions` with an already-bound `runTools` function, e.g. `bridge.runTools`).
+
+Depends only on `ai.matey.types` - `ai.matey.core` itself is untouched by this change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2736,18 +2736,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -4014,7 +4002,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4028,7 +4015,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4042,7 +4028,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4056,7 +4041,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4070,7 +4054,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4084,7 +4067,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4098,7 +4080,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4112,7 +4093,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4126,7 +4106,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4140,7 +4119,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4154,7 +4132,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4168,7 +4145,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4182,7 +4158,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4196,7 +4171,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4210,7 +4184,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4224,7 +4197,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4238,7 +4210,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4252,7 +4223,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4266,7 +4236,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4280,7 +4249,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4294,7 +4262,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4308,7 +4275,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4322,7 +4288,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4336,7 +4301,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4350,7 +4314,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4680,19 +4643,6 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -5399,6 +5349,10 @@
     },
     "node_modules/ai.matey.http.core": {
       "resolved": "packages/http.core",
+      "link": true
+    },
+    "node_modules/ai.matey.mcp": {
+      "resolved": "packages/mcp",
       "link": true
     },
     "node_modules/ai.matey.middleware": {
@@ -6295,14 +6249,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -8216,20 +8162,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -9198,17 +9130,6 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/js-tokens": {
@@ -14464,29 +14385,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
@@ -14818,34 +14716,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/terser": {
-      "version": "5.44.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
-      "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.15.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/test-exclude": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
@@ -15047,538 +14917,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "devOptional": true,
       "license": "0BSD"
-    },
-    "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
-      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
-      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
-      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
-      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
-      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
-      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
-      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
-      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
-      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
-      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
-      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
-      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
-      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
-      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
-      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
-      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
-      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
-      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
-      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
-      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
-      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
-      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
-      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/esbuild": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
-      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.0",
-        "@esbuild/android-arm": "0.27.0",
-        "@esbuild/android-arm64": "0.27.0",
-        "@esbuild/android-x64": "0.27.0",
-        "@esbuild/darwin-arm64": "0.27.0",
-        "@esbuild/darwin-x64": "0.27.0",
-        "@esbuild/freebsd-arm64": "0.27.0",
-        "@esbuild/freebsd-x64": "0.27.0",
-        "@esbuild/linux-arm": "0.27.0",
-        "@esbuild/linux-arm64": "0.27.0",
-        "@esbuild/linux-ia32": "0.27.0",
-        "@esbuild/linux-loong64": "0.27.0",
-        "@esbuild/linux-mips64el": "0.27.0",
-        "@esbuild/linux-ppc64": "0.27.0",
-        "@esbuild/linux-riscv64": "0.27.0",
-        "@esbuild/linux-s390x": "0.27.0",
-        "@esbuild/linux-x64": "0.27.0",
-        "@esbuild/netbsd-arm64": "0.27.0",
-        "@esbuild/netbsd-x64": "0.27.0",
-        "@esbuild/openbsd-arm64": "0.27.0",
-        "@esbuild/openbsd-x64": "0.27.0",
-        "@esbuild/openharmony-arm64": "0.27.0",
-        "@esbuild/sunos-x64": "0.27.0",
-        "@esbuild/win32-arm64": "0.27.0",
-        "@esbuild/win32-ia32": "0.27.0",
-        "@esbuild/win32-x64": "0.27.0"
-      }
     },
     "node_modules/turbo": {
       "version": "2.10.3",
@@ -16589,7 +15927,7 @@
       }
     },
     "packages/ai.matey": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -16600,7 +15938,7 @@
       }
     },
     "packages/ai.matey.core": {
-      "version": "0.3.2",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "ai.matey.errors": "*",
@@ -16663,7 +16001,7 @@
       "license": "MIT"
     },
     "packages/ai.matey.errors": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "ai.matey.types": "*"
@@ -16677,7 +16015,7 @@
       }
     },
     "packages/ai.matey.testing": {
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "ai.matey.types": "*",
@@ -16692,7 +16030,7 @@
       }
     },
     "packages/ai.matey.types": {
-      "version": "0.4.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -16703,7 +16041,7 @@
       }
     },
     "packages/ai.matey.utils": {
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "ai.matey.errors": "*",
@@ -16727,7 +16065,7 @@
     },
     "packages/backend": {
       "name": "ai.matey.backend",
-      "version": "0.6.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "ai.matey.errors": "*",
@@ -16745,7 +16083,7 @@
     },
     "packages/backend-browser": {
       "name": "ai.matey.backend.browser",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "ai.matey.errors": "*",
@@ -16771,7 +16109,7 @@
     },
     "packages/cli": {
       "name": "ai.matey.cli",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "ai.matey.backend": "*",
@@ -16812,7 +16150,7 @@
     },
     "packages/frontend": {
       "name": "ai.matey.frontend",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "ai.matey.errors": "*",
@@ -16830,7 +16168,7 @@
     },
     "packages/http": {
       "name": "ai.matey.http",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "ai.matey.core": "*",
@@ -16874,7 +16212,7 @@
     },
     "packages/http.core": {
       "name": "ai.matey.http.core",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "ai.matey.core": "*",
@@ -16891,9 +16229,24 @@
         "node": ">=18.0.0"
       }
     },
+    "packages/mcp": {
+      "name": "ai.matey.mcp",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ai.matey.types": "*"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "packages/middleware": {
       "name": "ai.matey.middleware",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "ai.matey.core": "*",
@@ -16941,7 +16294,7 @@
     },
     "packages/native-apple": {
       "name": "ai.matey.native.apple",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "ai.matey.errors": "*",
@@ -16959,7 +16312,7 @@
     },
     "packages/native-model-runner": {
       "name": "ai.matey.native.model-runner",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "ai.matey.errors": "*",
@@ -16977,7 +16330,7 @@
     },
     "packages/native-node-llamacpp": {
       "name": "ai.matey.native.node-llamacpp",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "ai.matey.errors": "*",
@@ -17003,7 +16356,7 @@
     },
     "packages/patterns": {
       "name": "ai.matey.patterns",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "ai.matey.core": "*",
@@ -17020,7 +16373,7 @@
     },
     "packages/react-core": {
       "name": "ai.matey.react.core",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "ai.matey.core": "*",
@@ -17047,7 +16400,7 @@
     },
     "packages/react-hooks": {
       "name": "ai.matey.react.hooks",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "ai.matey.react.core": "*",
@@ -17074,7 +16427,7 @@
     },
     "packages/react-nextjs": {
       "name": "ai.matey.react.nextjs",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "ai.matey.core": "*",
@@ -17106,7 +16459,7 @@
     },
     "packages/react-stream": {
       "name": "ai.matey.react.stream",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "ai.matey.react.core": "*",
@@ -17132,7 +16485,7 @@
     },
     "packages/wrapper": {
       "name": "ai.matey.wrapper",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "ai.matey.frontend": "*",

--- a/packages/mcp/LICENSE
+++ b/packages/mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 AI Matey Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "ai.matey.mcp",
+  "version": "0.0.0",
+  "description": "MCP (Model Context Protocol) tool-calling for AI Matey - translate MCP tools into the IR tool-execution loop via an injectable client",
+  "type": "module",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "readme.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "npm run build:esm && npm run build:cjs && npm run build:types",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:types": "tsc -p tsconfig.types.json",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts",
+    "lint:fix": "eslint src --ext .ts --fix",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "ai.matey.types": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  },
+  "keywords": [
+    "ai",
+    "llm",
+    "mcp",
+    "model-context-protocol",
+    "tool-calling",
+    "ai-matey"
+  ],
+  "author": "AI Matey",
+  "license": "MIT",
+  "homepage": "https://github.com/johnhenry/ai.matey#readme",
+  "bugs": {
+    "url": "https://github.com/johnhenry/ai.matey/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/johnhenry/ai.matey.git",
+    "directory": "packages/mcp"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/mcp/readme.md
+++ b/packages/mcp/readme.md
@@ -1,0 +1,89 @@
+# ai.matey.mcp
+
+MCP (Model Context Protocol) tool-calling for the [ai.matey](https://github.com/johnhenry/ai.matey)
+Universal AI Adapter System — translate an MCP server's tools into the agentic tool-execution
+loop `ai.matey.core`'s `Bridge` already ships (`bridge.runTools()`), via an injectable client.
+
+```bash
+npm install ai.matey.mcp
+```
+
+No hard (or peer) dependency on any MCP SDK — `ai.matey.mcp` depends only on `ai.matey.types` and
+a small structural interface (`McpClientLike`: `listTools`, `callTool`) that any MCP client can
+satisfy: the official `@modelcontextprotocol/sdk`, [`mcp-query`](https://github.com/johnhenry/mcp-query)
+(`@johnhenry/mcpq`), or a test fake.
+
+## Why this is small
+
+`ai.matey.core` already has a complete agentic loop (`Bridge.runTools()` / `createRunTools()`):
+execute → if the model requests tools, run them → append results → re-execute, until the model
+answers. This package doesn't reimplement any of that — it just converts MCP tools into the
+`ToolDefinition` shape that loop already consumes, so MCP tool-calling gets the same validation,
+iteration limits, and parallel execution for free.
+
+## Quick start
+
+```typescript
+import { Bridge } from 'ai.matey.core';
+import { OpenAIFrontendAdapter } from 'ai.matey.frontend';
+import { OpenAIBackendAdapter } from 'ai.matey.backend';
+import { runMcpTools } from 'ai.matey.mcp';
+
+// Any client satisfying McpClientLike - e.g. an mcp-query MCPClient already
+// connected to one or more servers.
+declare const mcpClient: import('ai.matey.mcp').McpClientLike;
+
+const bridge = new Bridge(
+  new OpenAIFrontendAdapter(),
+  new OpenAIBackendAdapter({ apiKey: process.env.OPENAI_API_KEY })
+);
+
+const result = await runMcpTools(bridge.runTools, {
+  client: mcpClient,
+  prompt: 'What files changed in the last commit?',
+});
+
+console.log(result.text);
+```
+
+## API
+
+| Export | Purpose |
+|---|---|
+| `McpClientLike` | The structural interface an injected MCP client must satisfy (`listTools`, `callTool`) |
+| `mcpToolToIRTool(tool)` | Convert one MCP tool schema to an `IRTool` |
+| `extractMcpResultText(result)` | Best-effort text extraction from an MCP `CallToolResult` |
+| `mcpToolsToDefinitions(client, options?)` | List an MCP client's tools and build a `Record<string, ToolDefinition>` |
+| `runMcpTools(runTools, options)` | Run `bridge.runTools()` (or any compatible `runTools` function) against an MCP client's tools |
+
+`mcpToolsToDefinitions` and `runMcpTools` both accept:
+- `server?: string` — which server to list/call tools against, for multi-server clients
+- `toolFilter?: (tool: McpToolSchema) => boolean` — only include matching tools
+- `signal?: AbortSignal` — forwarded to `callTool`
+
+## Using your own tools object
+
+If you want more control than `runMcpTools` gives you (e.g. mixing MCP tools with hand-written
+ones), use `mcpToolsToDefinitions` directly and call `bridge.runTools()` yourself:
+
+```typescript
+import { mcpToolsToDefinitions } from 'ai.matey.mcp';
+
+const mcpTools = await mcpToolsToDefinitions(mcpClient);
+
+const result = await bridge.runTools({
+  prompt: 'Summarize the open issues.',
+  tools: { ...mcpTools, myOwnTool: { description: '...', parameters: {...}, execute: async () => {...} } },
+});
+```
+
+## WebMCP compatibility
+
+Works with WebMCP-exposed tools (tools registered in-page via `document.modelContext`, consumed by
+a browser-side agent) without any changes here - `mcp-query` ships `webMcpToolServer()`, an
+in-memory MCP-server shim you can plug into `new MCPClient({ servers: { page: webMcpToolServer() } })`.
+Any `MCPClient` built that way already satisfies `McpClientLike`.
+
+## License
+
+MIT

--- a/packages/mcp/src/convert.ts
+++ b/packages/mcp/src/convert.ts
@@ -1,0 +1,49 @@
+/**
+ * MCP <-> IR Translation
+ *
+ * Pure functions converting between MCP's tool/result shapes and ai.matey's
+ * IR types. No client, no I/O - just the mapping.
+ *
+ * @module
+ */
+
+import type { IRTool, JSONSchema } from 'ai.matey.types';
+import type { McpCallToolResult, McpContentBlock, McpToolSchema } from './types.js';
+
+/**
+ * Convert an MCP tool schema to an IR tool definition.
+ *
+ * `IRTool.description` is required; MCP's is optional, so a missing
+ * description becomes an empty string rather than `undefined`.
+ */
+export function mcpToolToIRTool(tool: McpToolSchema): IRTool {
+  return {
+    name: tool.name,
+    description: tool.description ?? '',
+    parameters: tool.inputSchema as unknown as JSONSchema,
+  };
+}
+
+/**
+ * Extract a best-effort text representation of an MCP tool call result, for
+ * feeding back to the model as a tool result.
+ *
+ * Joins `text` fields from content blocks; if none are present, falls back
+ * to JSON-stringifying `structuredContent` (or the raw content array).
+ */
+export function extractMcpResultText(result: McpCallToolResult): string {
+  const text = result.content
+    .filter((block): block is McpContentBlockWithText => typeof block.text === 'string')
+    .map((block) => block.text)
+    .join('');
+
+  if (text.length > 0) {
+    return text;
+  }
+
+  return JSON.stringify(result.structuredContent ?? result.content);
+}
+
+interface McpContentBlockWithText extends McpContentBlock {
+  readonly text: string;
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * ai.matey.mcp
+ *
+ * MCP (Model Context Protocol) tool-calling for AI Matey. Translates MCP
+ * tools into the `ToolDefinition` shape consumed by `ai.matey.core`'s
+ * `Bridge.runTools()` agentic loop, via an injectable MCP client - no hard
+ * (or peer) dependency on any MCP SDK.
+ *
+ * @module
+ */
+
+export type { McpClientLike, McpToolSchema, McpContentBlock, McpCallToolResult } from './types.js';
+
+export { mcpToolToIRTool, extractMcpResultText } from './convert.js';
+
+export { mcpToolsToDefinitions, type McpToolsToDefinitionsOptions } from './tool-definitions.js';
+
+export { runMcpTools, type RunMcpToolsOptions } from './run-mcp-tools.js';

--- a/packages/mcp/src/run-mcp-tools.ts
+++ b/packages/mcp/src/run-mcp-tools.ts
@@ -1,0 +1,51 @@
+/**
+ * MCP Tool-Execution Convenience Wrapper
+ *
+ * `runMcpTools(runTools, options)` composes `mcpToolsToDefinitions` with an
+ * already-existing `runTools` function (e.g. `bridge.runTools`) from the
+ * *outside* - this package never imports `ai.matey.core`, matching
+ * `createRunTools`'s own `RunToolsBridge` structural-typing idiom.
+ *
+ * @module
+ */
+
+import type { RunToolsOptions, RunToolsResult } from 'ai.matey.types';
+import { mcpToolsToDefinitions } from './tool-definitions.js';
+import type { McpClientLike, McpToolSchema } from './types.js';
+
+export interface RunMcpToolsOptions extends Omit<RunToolsOptions, 'tools'> {
+  /** The injected MCP client to list/call tools against. */
+  readonly client: McpClientLike;
+
+  /** Which server to list/call tools against (for multi-server clients). */
+  readonly server?: string;
+
+  /** Only include tools for which this returns true. */
+  readonly toolFilter?: (tool: McpToolSchema) => boolean;
+}
+
+/**
+ * Run an MCP-backed agentic tool-call loop.
+ *
+ * @param runTools - A bound `runTools` function, e.g. `bridge.runTools`
+ *   (every `Bridge` instance exposes this already).
+ * @param options - MCP client plus the usual `RunToolsOptions` (`prompt`/
+ *   `messages`, `maxIterations`, etc.) minus `tools`, which is built from
+ *   the MCP client automatically.
+ *
+ * @example
+ * ```typescript
+ * const result = await runMcpTools(bridge.runTools, {
+ *   client: mcpClient,
+ *   prompt: 'What files changed in the last commit?',
+ * });
+ * ```
+ */
+export async function runMcpTools(
+  runTools: (options: RunToolsOptions) => Promise<RunToolsResult>,
+  options: RunMcpToolsOptions
+): Promise<RunToolsResult> {
+  const { client, server, toolFilter, signal, ...runToolsOptions } = options;
+  const tools = await mcpToolsToDefinitions(client, { server, signal, toolFilter });
+  return runTools({ ...runToolsOptions, signal, tools });
+}

--- a/packages/mcp/src/tool-definitions.ts
+++ b/packages/mcp/src/tool-definitions.ts
@@ -1,0 +1,63 @@
+/**
+ * MCP Tools -> ToolDefinition
+ *
+ * Converts an injected MCP client's tools into the `ToolDefinition` shape
+ * consumed by `ai.matey.core`'s `Bridge.runTools()` / `createRunTools()`
+ * agentic loop - so MCP tool-calling reuses that loop's validation,
+ * iteration, and parallel-execution logic rather than reimplementing it.
+ *
+ * @module
+ */
+
+import type { ToolDefinition } from 'ai.matey.types';
+import { extractMcpResultText, mcpToolToIRTool } from './convert.js';
+import type { McpClientLike, McpToolSchema } from './types.js';
+
+export interface McpToolsToDefinitionsOptions {
+  /** Which server to list/call tools against (for multi-server clients). */
+  readonly server?: string;
+
+  /** Abort signal forwarded to `listTools`/`callTool`. */
+  readonly signal?: AbortSignal;
+
+  /** Only include tools for which this returns true. */
+  readonly toolFilter?: (tool: McpToolSchema) => boolean;
+}
+
+/**
+ * List an MCP client's tools and convert them into a `Record<string,
+ * ToolDefinition>` ready to pass as `RunToolsOptions.tools`.
+ *
+ * Each `execute` calls `client.callTool(...)`. Per `runTools`'s documented
+ * contract ("thrown errors become `isError: true` tool results rather than
+ * aborting the loop"), an MCP result with `isError: true` is converted into
+ * a thrown `Error` - no special sentinel return value is needed.
+ */
+export async function mcpToolsToDefinitions(
+  client: McpClientLike,
+  options: McpToolsToDefinitionsOptions = {}
+): Promise<Record<string, ToolDefinition>> {
+  const { server, signal, toolFilter } = options;
+
+  const tools = await client.listTools(server);
+  const filtered = toolFilter ? tools.filter(toolFilter) : tools;
+
+  const definitions: Record<string, ToolDefinition> = {};
+
+  for (const tool of filtered) {
+    const irTool = mcpToolToIRTool(tool);
+    definitions[tool.name] = {
+      description: irTool.description,
+      parameters: irTool.parameters,
+      execute: async (input) => {
+        const result = await client.callTool(tool.name, input, { server, signal });
+        if (result.isError) {
+          throw new Error(extractMcpResultText(result));
+        }
+        return extractMcpResultText(result);
+      },
+    };
+  }
+
+  return definitions;
+}

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -1,0 +1,72 @@
+/**
+ * MCP Structural Types
+ *
+ * Minimal structural interfaces describing the subset of an MCP client's
+ * surface this package needs - list tools, call a tool. Deliberately not
+ * imported from `@modelcontextprotocol/sdk` or any specific client library:
+ * this package has no hard (or peer) dependency on any MCP SDK. Any client
+ * satisfying `McpClientLike` - the official SDK wrapped by hand, `mcp-query`
+ * (`@johnhenry/mcpq`), or a test fake - works without ai.matey ever needing
+ * to know it exists.
+ *
+ * @module
+ */
+
+/**
+ * A tool as reported by an MCP server (raw MCP spec shape: `name`,
+ * `description?`, `inputSchema` as JSON Schema).
+ */
+export interface McpToolSchema {
+  readonly name: string;
+  readonly description?: string;
+  readonly inputSchema: {
+    readonly type?: string;
+    readonly properties?: Record<string, unknown>;
+    readonly required?: readonly string[];
+    readonly [key: string]: unknown;
+  };
+}
+
+/**
+ * A single content block from an MCP tool call result (text, image, etc.).
+ * Only `text` is inspected here; other block types pass through untouched.
+ */
+export interface McpContentBlock {
+  readonly type: string;
+  readonly text?: string;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * The result of an MCP `tools/call` (raw MCP spec `CallToolResult` shape).
+ */
+export interface McpCallToolResult {
+  readonly content: readonly McpContentBlock[];
+  readonly structuredContent?: Record<string, unknown>;
+  readonly isError?: boolean;
+}
+
+/**
+ * The subset of an MCP client's surface this package depends on.
+ *
+ * `mcp-query`'s `MCPClient` instances satisfy this structurally: its
+ * `listTools(server)` is synchronous (assignable to `Promise<T[]> | T[]`)
+ * and `callTool(name, args, opts?)` is a plain one-shot promise whose
+ * default instantiation is the raw `CallToolResult` passthrough.
+ */
+export interface McpClientLike {
+  /**
+   * List tools available from a server. May be sync or async - callers
+   * should `await` the result either way.
+   */
+  listTools(server?: string): Promise<McpToolSchema[]> | McpToolSchema[];
+
+  /**
+   * Call a tool by name with arguments, returning the raw MCP result.
+   */
+  callTool(
+    name: string,
+    args: Record<string, unknown>,
+    opts?: { readonly server?: string; readonly signal?: AbortSignal }
+  ): Promise<McpCallToolResult>;
+}

--- a/packages/mcp/tsconfig.cjs.json
+++ b/packages/mcp/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "outDir": "./dist/cjs",
+    "declaration": false,
+    "declarationMap": false
+  }
+}

--- a/packages/mcp/tsconfig.esm.json
+++ b/packages/mcp/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "./dist/esm",
+    "declaration": false,
+    "declarationMap": false
+  }
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
+}

--- a/packages/mcp/tsconfig.types.json
+++ b/packages/mcp/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "./dist/types",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true
+  }
+}

--- a/scripts/staggered-publish.sh
+++ b/scripts/staggered-publish.sh
@@ -2,7 +2,7 @@
 #
 # Staggered Publish Script for ai.matey Monorepo
 #
-# Publishes all 21 packages to npm in dependency order with delays
+# Publishes all 23 packages to npm in dependency order with delays
 # to avoid rate limiting.
 #
 # Usage:
@@ -46,7 +46,7 @@ publish_package() {
   local pkg=$1
   TOTAL=$((TOTAL + 1))
 
-  echo -e "${BLUE}[$TOTAL/21]${NC} Publishing ${YELLOW}$pkg${NC}..."
+  echo -e "${BLUE}[$TOTAL/23]${NC} Publishing ${YELLOW}$pkg${NC}..."
 
   if $DRY_RUN; then
     echo "  → Would run: npm publish --workspace=$pkg --access public"
@@ -104,7 +104,7 @@ echo ""
 echo "╔══════════════════════════════════════════════════════════════╗"
 echo "║       ai.matey Staggered Publish Script                      ║"
 echo "║                                                              ║"
-echo "║  Publishing 21 packages in dependency order                  ║"
+echo "║  Publishing 23 packages in dependency order                  ║"
 echo "║  Delay between packages: ${DELAY_BETWEEN_PACKAGES}s                              ║"
 echo "║  Delay between batches: ${DELAY_BETWEEN_BATCHES}s                               ║"
 echo "╚══════════════════════════════════════════════════════════════╝"
@@ -179,6 +179,14 @@ wait_between "$DELAY_BETWEEN_BATCHES"
 # ============================================================================
 publish_batch "Patterns" \
   "ai.matey.patterns"
+
+wait_between "$DELAY_BETWEEN_BATCHES"
+
+# ============================================================================
+# BATCH 6c: MCP (depends only on types)
+# ============================================================================
+publish_batch "MCP" \
+  "ai.matey.mcp"
 
 wait_between "$DELAY_BETWEEN_BATCHES"
 

--- a/tests/unit/layering.test.ts
+++ b/tests/unit/layering.test.ts
@@ -37,4 +37,9 @@ describe('package layering', () => {
     const deps = dependenciesOf('ai.matey.types');
     expect(Object.keys(deps).filter((d) => d.startsWith('ai.matey'))).toEqual([]);
   });
+
+  it('ai.matey.mcp depends only on ai.matey.types (no core, no MCP SDK)', () => {
+    const deps = dependenciesOf('mcp');
+    expect(Object.keys(deps)).toEqual(['ai.matey.types']);
+  });
 });

--- a/tests/unit/mcp-convert.test.ts
+++ b/tests/unit/mcp-convert.test.ts
@@ -1,0 +1,70 @@
+/**
+ * MCP <-> IR translation (pure functions, no client).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mcpToolToIRTool, extractMcpResultText } from 'ai.matey.mcp';
+import type { McpCallToolResult, McpToolSchema } from 'ai.matey.mcp';
+
+describe('mcpToolToIRTool', () => {
+  it('maps name, description, and inputSchema through', () => {
+    const tool: McpToolSchema = {
+      name: 'get_weather',
+      description: 'Get current weather for a location',
+      inputSchema: {
+        type: 'object',
+        properties: { location: { type: 'string' } },
+        required: ['location'],
+      },
+    };
+
+    const irTool = mcpToolToIRTool(tool);
+
+    expect(irTool).toEqual({
+      name: 'get_weather',
+      description: 'Get current weather for a location',
+      parameters: tool.inputSchema,
+    });
+  });
+
+  it('falls back to an empty description when MCP omits it', () => {
+    const tool: McpToolSchema = { name: 'noop', inputSchema: { type: 'object' } };
+    const irTool = mcpToolToIRTool(tool);
+    expect(irTool.description).toBe('');
+  });
+});
+
+describe('extractMcpResultText', () => {
+  it('joins text content blocks', () => {
+    const result: McpCallToolResult = {
+      content: [
+        { type: 'text', text: 'Hello' },
+        { type: 'text', text: ' world' },
+      ],
+    };
+    expect(extractMcpResultText(result)).toBe('Hello world');
+  });
+
+  it('ignores non-text blocks when joining', () => {
+    const result: McpCallToolResult = {
+      content: [
+        { type: 'text', text: 'partial' },
+        { type: 'image', data: 'base64...' },
+      ],
+    };
+    expect(extractMcpResultText(result)).toBe('partial');
+  });
+
+  it('falls back to structuredContent when there is no text', () => {
+    const result: McpCallToolResult = {
+      content: [{ type: 'image', data: 'base64...' }],
+      structuredContent: { temperature: 72 },
+    };
+    expect(extractMcpResultText(result)).toBe(JSON.stringify({ temperature: 72 }));
+  });
+
+  it('falls back to the raw content array when there is neither text nor structuredContent', () => {
+    const result: McpCallToolResult = { content: [{ type: 'image', data: 'base64...' }] };
+    expect(extractMcpResultText(result)).toBe(JSON.stringify(result.content));
+  });
+});

--- a/tests/unit/mcp-run-tools.test.ts
+++ b/tests/unit/mcp-run-tools.test.ts
@@ -1,0 +1,81 @@
+/**
+ * runMcpTools - composes mcpToolsToDefinitions with an injected `runTools`
+ * function (e.g. `bridge.runTools`), without depending on ai.matey.core.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { runMcpTools } from 'ai.matey.mcp';
+import type { McpClientLike, McpToolSchema } from 'ai.matey.mcp';
+import type { RunToolsOptions, RunToolsResult } from 'ai.matey.types';
+
+const WEATHER_TOOL: McpToolSchema = {
+  name: 'get_weather',
+  description: 'Get current weather',
+  inputSchema: { type: 'object' },
+};
+
+function makeFakeClient(): McpClientLike {
+  return {
+    listTools: () => [WEATHER_TOOL],
+    callTool: async () => ({ content: [{ type: 'text', text: 'Sunny' }] }),
+  };
+}
+
+function makeFakeRunTools(): {
+  runTools: (options: RunToolsOptions) => Promise<RunToolsResult>;
+  received: RunToolsOptions[];
+} {
+  const received: RunToolsOptions[] = [];
+  const runTools = vi.fn(async (options: RunToolsOptions): Promise<RunToolsResult> => {
+    received.push(options);
+    return {
+      text: 'done',
+      response: {
+        message: { role: 'assistant', content: 'done' },
+        finishReason: 'stop',
+        metadata: { requestId: 'r1', timestamp: Date.now(), provenance: {} },
+      },
+      messages: [],
+      steps: [],
+      finishReason: 'stop',
+      totalUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    };
+  });
+  return { runTools, received };
+}
+
+describe('runMcpTools', () => {
+  it('builds tools from the MCP client and forwards other options to runTools', async () => {
+    const client = makeFakeClient();
+    const { runTools, received } = makeFakeRunTools();
+
+    const result = await runMcpTools(runTools, {
+      client,
+      prompt: 'What is the weather?',
+      maxIterations: 3,
+    });
+
+    expect(result.text).toBe('done');
+    expect(received).toHaveLength(1);
+    expect(received[0]?.prompt).toBe('What is the weather?');
+    expect(received[0]?.maxIterations).toBe(3);
+    expect(Object.keys(received[0]?.tools ?? {})).toEqual(['get_weather']);
+  });
+
+  it('does not forward client/server/toolFilter to runTools', async () => {
+    const client = makeFakeClient();
+    const { runTools, received } = makeFakeRunTools();
+
+    await runMcpTools(runTools, {
+      client,
+      server: 'backend',
+      toolFilter: () => true,
+      prompt: 'hi',
+    });
+
+    const forwarded = received[0] as Record<string, unknown>;
+    expect(forwarded.client).toBeUndefined();
+    expect(forwarded.server).toBeUndefined();
+    expect(forwarded.toolFilter).toBeUndefined();
+  });
+});

--- a/tests/unit/mcp-tool-definitions.test.ts
+++ b/tests/unit/mcp-tool-definitions.test.ts
@@ -1,0 +1,82 @@
+/**
+ * mcpToolsToDefinitions - MCP tools -> ToolDefinition, backed by a fake
+ * McpClientLike (no real MCP server, no mcp-query dependency).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mcpToolsToDefinitions } from 'ai.matey.mcp';
+import type { McpCallToolResult, McpClientLike, McpToolSchema } from 'ai.matey.mcp';
+
+const WEATHER_TOOL: McpToolSchema = {
+  name: 'get_weather',
+  description: 'Get current weather for a location',
+  inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
+};
+
+const FAIL_TOOL: McpToolSchema = {
+  name: 'always_fails',
+  description: 'A tool that always errors',
+  inputSchema: { type: 'object' },
+};
+
+function makeFakeClient(): {
+  client: McpClientLike;
+  calls: Array<{ name: string; args: Record<string, unknown>; server?: string }>;
+} {
+  const calls: Array<{ name: string; args: Record<string, unknown>; server?: string }> = [];
+
+  const client: McpClientLike = {
+    listTools: () => [WEATHER_TOOL, FAIL_TOOL],
+    callTool: async (name, args, opts) => {
+      calls.push({ name, args, server: opts?.server });
+      if (name === 'always_fails') {
+        return { content: [{ type: 'text', text: 'boom' }], isError: true };
+      }
+      return { content: [{ type: 'text', text: 'Sunny, 72F' }] } satisfies McpCallToolResult;
+    },
+  };
+
+  return { client, calls };
+}
+
+describe('mcpToolsToDefinitions', () => {
+  it('builds a ToolDefinition per listed tool', async () => {
+    const { client } = makeFakeClient();
+    const definitions = await mcpToolsToDefinitions(client);
+
+    expect(Object.keys(definitions).sort()).toEqual(['always_fails', 'get_weather']);
+    expect(definitions.get_weather?.description).toBe('Get current weather for a location');
+    expect(definitions.get_weather?.parameters).toEqual(WEATHER_TOOL.inputSchema);
+  });
+
+  it('execute() calls through to client.callTool with the right args and returns extracted text', async () => {
+    const { client, calls } = makeFakeClient();
+    const definitions = await mcpToolsToDefinitions(client, { server: 'backend' });
+
+    const result = await definitions.get_weather?.execute(
+      { location: 'SF' },
+      { toolCallId: 'call_1', messages: [] }
+    );
+
+    expect(result).toBe('Sunny, 72F');
+    expect(calls).toEqual([{ name: 'get_weather', args: { location: 'SF' }, server: 'backend' }]);
+  });
+
+  it('execute() throws when the MCP result has isError: true', async () => {
+    const { client } = makeFakeClient();
+    const definitions = await mcpToolsToDefinitions(client);
+
+    await expect(
+      definitions.always_fails?.execute({}, { toolCallId: 'call_2', messages: [] })
+    ).rejects.toThrow('boom');
+  });
+
+  it('toolFilter excludes non-matching tools', async () => {
+    const { client } = makeFakeClient();
+    const definitions = await mcpToolsToDefinitions(client, {
+      toolFilter: (tool) => tool.name === 'get_weather',
+    });
+
+    expect(Object.keys(definitions)).toEqual(['get_weather']);
+  });
+});


### PR DESCRIPTION
## Summary

New package `ai.matey.mcp` translating MCP (Model Context Protocol) tools into the `ToolDefinition` shape already consumed by `ai.matey.core`'s `Bridge.runTools()` agentic loop.

- **No hard (or peer) dependency on any MCP SDK.** Any client satisfying a small structural interface (`McpClientLike`: `listTools`, `callTool`) works: the official `@modelcontextprotocol/sdk` wrapped by hand, [`mcp-query`](https://github.com/johnhenry/mcp-query) (`@johnhenry/mcpq`), or a test fake.
- **`ai.matey.core` is completely untouched.** The package composes `runTools` from the outside (`runMcpTools(bridge.runTools, { client, prompt })`), matching `createRunTools`'s own `RunToolsBridge` structural-typing idiom - `ai.matey.mcp` depends only on `ai.matey.types`.
- Compatible with **WebMCP**-exposed tools (in-page `document.modelContext` tools consumed by a browser-side agent) with zero changes on either side, via `mcp-query`'s `webMcpToolServer()` shim.
- Also registers the new package in `scripts/staggered-publish.sh` (a hardcoded, dependency-ordered batch list - a new package silently never gets published otherwise) and corrects its stale "21 packages" count.

## API

- `McpClientLike` / `McpToolSchema` / `McpCallToolResult` - structural types
- `mcpToolToIRTool` / `extractMcpResultText` - pure MCP↔IR conversion
- `mcpToolsToDefinitions(client, options?)` - MCP tools → `Record<string, ToolDefinition>`
- `runMcpTools(runTools, options)` - convenience wrapper: builds tools from an MCP client, then calls the given `runTools` function (e.g. `bridge.runTools`)

## Test plan
- [x] `npm run build` (all 24 workspace packages, including the new one)
- [x] `npm test` (1497 passed, 11 pre-existing skips, 0 failures)
- [x] `npm run lint` (0 errors)
- [x] New tests: `mcp-convert.test.ts` (6), `mcp-tool-definitions.test.ts` (4, via a fake `McpClientLike`), `mcp-run-tools.test.ts` (2, via a fake `runTools` function) - no real MCP server or `mcp-query` dependency needed
- [x] Added a `layering.test.ts` guard confirming `ai.matey.mcp` depends only on `ai.matey.types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)