### PR TITLE
Add GitHub Models and DashScope (Qwen) backend adapters

### DIFF
--- a/.changeset/github-models-dashscope-providers.md
+++ b/.changeset/github-models-dashscope-providers.md
@@ -1,0 +1,20 @@
+---
+'ai.matey.backend': minor
+---
+
+Add two new backend provider adapters:
+
+- `GitHubModelsBackendAdapter` - GitHub Models, an OpenAI-compatible gateway free to any GitHub
+  account (rate limits scale with Copilot subscription tier), fronting models from OpenAI, Meta,
+  DeepSeek, Mistral, Microsoft, and Cohere. Defaults to `openai/gpt-4o-mini` (the most generously
+  rate-limited tier). `estimateCost()` returns `null` since usage is metered against Copilot rate
+  limits, not billed per-token.
+- `DashScopeBackendAdapter` - Alibaba Cloud Model Studio's OpenAI-compatible mode, hosting the
+  Qwen model family. Defaults to `qwen3.7-plus` and the international (Singapore)
+  `dashscope-intl.aliyuncs.com` endpoint; override `baseURL` for mainland China deployments.
+  `estimateCost()` returns `null` - DashScope pricing isn't consistently published across
+  regions/models in English-language docs.
+
+Both follow the same OpenAI-compatible-passthrough pattern as `together-ai`/`fireworks`/
+`openrouter`: `structuredOutput: 'fallback'` and `tools: false` (with a warning) rather than
+claiming native tool-calling support that isn't actually mapped.

--- a/docs/IR-FORMAT.md
+++ b/docs/IR-FORMAT.md
@@ -789,7 +789,7 @@ Backends handle `responseFormat` one of two ways, reported via `IRCapabilities.s
 | Anthropic | Native (`output_config: { format: { type: 'json_schema', schema } }`) |
 | Gemini | Native (`generationConfig.responseSchema` + `responseMimeType: 'application/json'`) |
 | Groq, DeepSeek, Inception, Moonshot, NVIDIA, LM Studio, SambaNova | Native (OpenAI-compatible - inherit OpenAI's mapping unchanged) |
-| All other backends (AI21, Anyscale, AWS Bedrock, Azure OpenAI, Cerebras, Cloudflare, Cohere, DeepInfra, Fireworks, Hugging Face, Mistral, Ollama, OpenRouter, Perplexity, Replicate, Together AI, xAI) | Fallback (prompt injection + best-effort JSON extraction) |
+| All other backends (AI21, Anyscale, AWS Bedrock, Azure OpenAI, Cerebras, Cloudflare, Cohere, DeepInfra, Fireworks, Hugging Face, Mistral, Ollama, OpenRouter, Perplexity, Replicate, Together AI, xAI, GitHub Models, DashScope) | Fallback (prompt injection + best-effort JSON extraction) |
 
 ### Example
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,8 +23,8 @@ Development roadmap and strategic direction for the Universal AI Adapter System.
 - ✅ Provider-agnostic request/response handling
 
 ### Providers
-- ✅ **24 Backend Providers** in `ai.matey.backend`:
-  OpenAI, Anthropic, Gemini, Mistral, Cohere, Groq, Ollama, AI21, Anyscale, AWS Bedrock, Azure OpenAI, Cerebras, Cloudflare, DeepInfra, DeepSeek, Fireworks, HuggingFace, LMStudio, NVIDIA, OpenRouter, Perplexity, Replicate, Together AI, XAI
+- ✅ **26 Backend Providers** in `ai.matey.backend`:
+  OpenAI, Anthropic, Gemini, Mistral, Cohere, Groq, Ollama, AI21, Anyscale, AWS Bedrock, Azure OpenAI, Cerebras, Cloudflare, DeepInfra, DeepSeek, Fireworks, HuggingFace, LMStudio, NVIDIA, OpenRouter, Perplexity, Replicate, Together AI, XAI, GitHub Models, DashScope (Alibaba Cloud Model Studio)
 - ✅ **7 Frontend Adapters** in `ai.matey.frontend`:
   OpenAI, Anthropic, Gemini, Mistral, Ollama, Chrome AI, Generic
 - ✅ **3 Browser Backends** in `ai.matey.backend.browser`:

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -287,6 +287,26 @@
         "default": "./dist/cjs/providers/sambanova.js"
       }
     },
+    "./github-models": {
+      "import": {
+        "types": "./dist/types/providers/github-models.d.ts",
+        "default": "./dist/esm/providers/github-models.js"
+      },
+      "require": {
+        "types": "./dist/types/providers/github-models.d.ts",
+        "default": "./dist/cjs/providers/github-models.js"
+      }
+    },
+    "./dashscope": {
+      "import": {
+        "types": "./dist/types/providers/dashscope.d.ts",
+        "default": "./dist/esm/providers/dashscope.js"
+      },
+      "require": {
+        "types": "./dist/types/providers/dashscope.d.ts",
+        "default": "./dist/cjs/providers/dashscope.js"
+      }
+    },
     "./shared": {
       "import": {
         "types": "./dist/types/shared.d.ts",

--- a/packages/backend/readme.md
+++ b/packages/backend/readme.md
@@ -12,7 +12,7 @@ npm install ai.matey.backend
 
 ## Included Providers
 
-This package includes adapters for **27 AI providers**:
+This package includes adapters for **29 AI providers**:
 
 ### Commercial APIs
 - **OpenAI** - GPT-4, GPT-4 Turbo, GPT-3.5
@@ -24,6 +24,7 @@ This package includes adapters for **27 AI providers**:
 - **AI21 Labs** - Jurassic models
 - **Moonshot AI** - Kimi models with long-context support (up to 128K)
 - **Inception Labs** - Mercury diffusion language models
+- **Alibaba Cloud Model Studio (DashScope)** - Qwen model family, OpenAI-compatible mode
 
 ### Cloud Providers
 - **AWS Bedrock** - Amazon's managed AI service
@@ -42,6 +43,7 @@ This package includes adapters for **27 AI providers**:
 ### Aggregators
 - **OpenRouter** - Multi-provider routing and fallback
 - **Perplexity** - Search-augmented models
+- **GitHub Models** - Free access to OpenAI, Meta, DeepSeek, Mistral & Microsoft models via any GitHub account
 
 ### Specialized
 - **Replicate** - ML model deployment

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -42,6 +42,8 @@ export * from './providers/xai.js';
 export * from './providers/inception.js';
 export * from './providers/moonshot.js';
 export * from './providers/sambanova.js';
+export * from './providers/github-models.js';
+export * from './providers/dashscope.js';
 
 // Note: The following adapters have been moved to ai.matey.backend.browser:
 // - chrome-ai (Chrome's built-in AI)

--- a/packages/backend/src/providers/dashscope.ts
+++ b/packages/backend/src/providers/dashscope.ts
@@ -1,0 +1,499 @@
+/**
+ * DashScope (Alibaba Cloud Model Studio) Backend Adapter
+ *
+ * Adapts Universal IR to Alibaba Cloud Model Studio's OpenAI-compatible mode.
+ * DashScope hosts the Qwen model family (commercial and open-source variants).
+ *
+ * @module
+ */
+
+import type { BackendAdapter, BackendAdapterConfig, AdapterMetadata } from 'ai.matey.types';
+import type { IREmbedRequest, IREmbedResponse } from 'ai.matey.types';
+import {
+  executeOpenAICompatibleEmbed,
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+  buildToolsUnsupportedWarning,
+} from '../shared.js';
+import type {
+  IRChatRequest,
+  IRChatResponse,
+  IRChatStream,
+  IRMessage,
+  IRStreamChunk,
+  FinishReason,
+} from 'ai.matey.types';
+import {
+  NetworkError,
+  ProviderError,
+  StreamError,
+  ErrorCode,
+  createErrorFromHttpResponse,
+} from 'ai.matey.errors';
+import { normalizeSystemMessages } from 'ai.matey.utils';
+import { getEffectiveStreamMode, mergeStreamingConfig } from 'ai.matey.utils';
+
+// ============================================================================
+// DashScope API Types (OpenAI-compatible mode)
+// ============================================================================
+
+export type DashScopeMessageContent =
+  | string
+  | Array<{ type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }>;
+
+export interface DashScopeMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: DashScopeMessageContent;
+  name?: string;
+  tool_calls?: Array<{
+    id: string;
+    type: 'function';
+    function: {
+      name: string;
+      arguments: string;
+    };
+  }>;
+}
+
+export interface DashScopeRequest {
+  model: string;
+  messages: DashScopeMessage[];
+  temperature?: number;
+  max_tokens?: number;
+  top_p?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
+  stop?: string[];
+  stream?: boolean;
+}
+
+export interface DashScopeResponse {
+  id: string;
+  object: 'chat.completion';
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: DashScopeMessage;
+    finish_reason: 'stop' | 'length' | 'tool_calls' | null;
+  }>;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+export interface DashScopeStreamChunk {
+  id: string;
+  object: 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: {
+      role?: 'assistant';
+      content?: string;
+    };
+    finish_reason: 'stop' | 'length' | null;
+  }>;
+}
+
+// ============================================================================
+// DashScope Backend Adapter
+// ============================================================================
+
+/**
+ * Backend adapter for Alibaba Cloud Model Studio's OpenAI-compatible mode.
+ *
+ * Features:
+ * - Qwen model family (qwen3.7-max/plus, qwen3.6-flash, and open-source Qwen)
+ * - OpenAI-compatible API (`/compatible-mode/v1`)
+ * - Vision model support (Qwen-VL family)
+ * - Free tier: 1,000,000 tokens per model on Alibaba Cloud International
+ */
+export class DashScopeBackendAdapter implements BackendAdapter<
+  DashScopeRequest,
+  DashScopeResponse
+> {
+  readonly metadata: AdapterMetadata;
+  private readonly config: BackendAdapterConfig;
+  private readonly baseURL: string;
+
+  constructor(config: BackendAdapterConfig) {
+    this.config = config;
+    // International (Singapore) endpoint by default; mainland China deployments
+    // should override baseURL with their region-specific compatible-mode URL.
+    this.baseURL = config.baseURL || 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1';
+    this.metadata = {
+      name: 'dashscope-backend',
+      version: '1.0.0',
+      provider: 'Alibaba Cloud Model Studio (DashScope)',
+      capabilities: {
+        embeddings: true,
+        maxEmbeddingBatchSize: 100,
+        streaming: true,
+        multiModal: true, // Qwen-VL family
+        tools: false, // Function calling
+        structuredOutput: 'fallback',
+        maxContextTokens: 131072,
+        systemMessageStrategy: 'in-messages',
+        supportsMultipleSystemMessages: true,
+        supportsTemperature: true,
+        supportsTopP: true,
+        supportsTopK: false,
+        supportsSeed: false,
+        supportsFrequencyPenalty: true,
+        supportsPresencePenalty: true,
+        maxStopSequences: 4,
+      },
+      config: {
+        baseURL: this.baseURL,
+      },
+    };
+  }
+
+  /**
+   * Convert IR to DashScope format.
+   */
+  public fromIR(request: IRChatRequest): DashScopeRequest {
+    const { messages } = normalizeSystemMessages(
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
+      this.metadata.capabilities.systemMessageStrategy,
+      this.metadata.capabilities.supportsMultipleSystemMessages
+    );
+
+    const dashScopeMessages: DashScopeMessage[] = messages.map((msg) => ({
+      role: msg.role,
+      content:
+        typeof msg.content === 'string'
+          ? msg.content
+          : msg.content.map((block) => {
+              if (block.type === 'text') {
+                return { type: 'text', text: block.text };
+              } else if (block.type === 'image') {
+                return {
+                  type: 'image_url',
+                  image_url: {
+                    url:
+                      block.source.type === 'url'
+                        ? block.source.url
+                        : `data:${block.source.mediaType};base64,${block.source.data}`,
+                  },
+                };
+              }
+              return { type: 'text', text: JSON.stringify(block) };
+            }),
+    }));
+
+    return {
+      model: request.parameters?.model || this.config.defaultModel || 'qwen3.7-plus',
+      messages: dashScopeMessages,
+      temperature: request.parameters?.temperature,
+      max_tokens: request.parameters?.maxTokens,
+      top_p: request.parameters?.topP,
+      frequency_penalty: request.parameters?.frequencyPenalty,
+      presence_penalty: request.parameters?.presencePenalty,
+      stop: request.parameters?.stopSequences ? [...request.parameters.stopSequences] : undefined,
+      stream: request.stream || false,
+    };
+  }
+
+  /**
+   * Convert DashScope response to IR.
+   */
+  public toIR(
+    response: DashScopeResponse,
+    originalRequest: IRChatRequest,
+    latencyMs: number
+  ): IRChatResponse {
+    const choice = response.choices[0];
+    if (!choice) {
+      throw new ProviderError({
+        code: ErrorCode.PROVIDER_ERROR,
+        message: 'No choices returned in response',
+        isRetryable: false,
+        provenance: { backend: this.metadata.name },
+      });
+    }
+
+    const rawContent =
+      typeof choice.message.content === 'string'
+        ? choice.message.content
+        : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join('');
+    const content = originalRequest.responseFormat
+      ? extractStructuredOutputJSON(rawContent)
+      : rawContent;
+    const message: IRMessage = {
+      role: choice.message.role === 'assistant' ? 'assistant' : 'user',
+      content,
+    };
+
+    const finishReasonMap: Record<string, FinishReason> = {
+      stop: 'stop',
+      length: 'length',
+      tool_calls: 'tool_calls',
+    };
+
+    const extraWarnings = [
+      ...(originalRequest.responseFormat
+        ? [buildResponseFormatFallbackWarning(this.metadata.name)]
+        : []),
+      ...(originalRequest.tools?.length ? [buildToolsUnsupportedWarning(this.metadata.name)] : []),
+    ];
+
+    return {
+      message,
+      finishReason: finishReasonMap[choice.finish_reason || 'stop'] || 'stop',
+      usage: response.usage
+        ? {
+            promptTokens: response.usage.prompt_tokens,
+            completionTokens: response.usage.completion_tokens,
+            totalTokens: response.usage.total_tokens,
+          }
+        : undefined,
+      metadata: {
+        ...originalRequest.metadata,
+        providerResponseId: response.id,
+        provenance: {
+          ...originalRequest.metadata.provenance,
+          backend: this.metadata.name,
+        },
+        custom: {
+          ...originalRequest.metadata.custom,
+          latencyMs,
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
+        },
+        warnings: extraWarnings.length
+          ? [...(originalRequest.metadata.warnings ?? []), ...extraWarnings]
+          : originalRequest.metadata.warnings,
+      },
+      raw: response as unknown as Record<string, unknown>,
+    };
+  }
+
+  /**
+   * Generate embeddings via the OpenAI-compatible /embeddings endpoint.
+   */
+  embed(request: IREmbedRequest, signal?: AbortSignal): Promise<IREmbedResponse> {
+    return executeOpenAICompatibleEmbed({
+      baseURL: this.baseURL,
+      headers: this.getHeaders(),
+      request,
+      backendName: this.metadata.name,
+      defaultModel: 'text-embedding-v4',
+      signal,
+    });
+  }
+
+  /**
+   * Execute non-streaming request.
+   */
+  async execute(request: IRChatRequest, signal?: AbortSignal): Promise<IRChatResponse> {
+    try {
+      const dashScopeRequest = this.fromIR(request);
+      dashScopeRequest.stream = false;
+
+      const startTime = Date.now();
+      const response = await fetch(`${this.baseURL}/chat/completions`, {
+        method: 'POST',
+        headers: this.getHeaders(),
+        body: JSON.stringify(dashScopeRequest),
+        signal,
+      });
+
+      if (!response.ok) {
+        throw createErrorFromHttpResponse(
+          response.status,
+          response.statusText,
+          await response.text(),
+          { backend: this.metadata.name }
+        );
+      }
+
+      const data = (await response.json()) as DashScopeResponse;
+      return this.toIR(data, request, Date.now() - startTime);
+    } catch (error) {
+      if (error instanceof NetworkError || error instanceof ProviderError) {
+        throw error;
+      }
+
+      throw new ProviderError({
+        code: ErrorCode.PROVIDER_ERROR,
+        message: `DashScope request failed: ${error instanceof Error ? error.message : String(error)}`,
+        isRetryable: true,
+        provenance: { backend: this.metadata.name },
+        cause: error instanceof Error ? error : undefined,
+      });
+    }
+  }
+
+  /**
+   * Execute streaming request.
+   */
+  async *executeStream(request: IRChatRequest, signal?: AbortSignal): IRChatStream {
+    try {
+      const dashScopeRequest = this.fromIR(request);
+      dashScopeRequest.stream = true;
+
+      const streamingConfig = mergeStreamingConfig(this.config.streaming);
+      const effectiveMode = getEffectiveStreamMode(request.streamMode, undefined, streamingConfig);
+      const includeBoth = streamingConfig.includeBoth || effectiveMode === 'accumulated';
+
+      const response = await fetch(`${this.baseURL}/chat/completions`, {
+        method: 'POST',
+        headers: this.getHeaders(),
+        body: JSON.stringify(dashScopeRequest),
+        signal,
+      });
+
+      if (!response.ok) {
+        throw createErrorFromHttpResponse(
+          response.status,
+          response.statusText,
+          await response.text(),
+          { backend: this.metadata.name }
+        );
+      }
+
+      if (!response.body) {
+        throw new StreamError({
+          code: ErrorCode.STREAM_ERROR,
+          message: 'No response body',
+          provenance: { backend: this.metadata.name },
+        });
+      }
+
+      let sequence = 0;
+      let contentBuffer = '';
+
+      yield {
+        type: 'start',
+        sequence: sequence++,
+        metadata: {
+          ...request.metadata,
+          provenance: {
+            ...request.metadata.provenance,
+            backend: this.metadata.name,
+          },
+        },
+      } as IRStreamChunk;
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() || '';
+
+          for (const line of lines) {
+            if (!line.trim() || !line.startsWith('data: ')) {
+              continue;
+            }
+
+            const data = line.slice(6).trim();
+            if (data === '[DONE]') {
+              continue;
+            }
+
+            try {
+              const chunk = JSON.parse(data) as DashScopeStreamChunk;
+              const delta = chunk.choices[0]?.delta?.content;
+
+              if (delta) {
+                contentBuffer += delta;
+
+                const contentChunk: IRStreamChunk = {
+                  type: 'content',
+                  sequence: sequence++,
+                  delta: delta,
+                  role: 'assistant',
+                };
+
+                if (includeBoth) {
+                  (contentChunk as any).accumulated = contentBuffer;
+                }
+
+                yield contentChunk;
+              }
+
+              if (chunk.choices[0]?.finish_reason) {
+                const finishReasonMap: Record<string, FinishReason> = {
+                  stop: 'stop',
+                  length: 'length',
+                };
+
+                yield {
+                  type: 'done',
+                  sequence: sequence++,
+                  finishReason: finishReasonMap[chunk.choices[0].finish_reason] || 'stop',
+                  message: { role: 'assistant', content: contentBuffer },
+                } as IRStreamChunk;
+              }
+            } catch (parseError) {
+              console.warn('Failed to parse SSE chunk:', data, parseError);
+            }
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    } catch (error) {
+      yield {
+        type: 'error',
+        sequence: 0,
+        error: {
+          code: error instanceof Error ? error.name : 'UNKNOWN_ERROR',
+          message: error instanceof Error ? error.message : String(error),
+        },
+      } as IRStreamChunk;
+    }
+  }
+
+  /**
+   * Get HTTP headers.
+   */
+  private getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.config.apiKey}`,
+    };
+
+    return { ...headers, ...this.config.headers };
+  }
+
+  /**
+   * Health check.
+   */
+  async healthCheck(): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.baseURL}/models`, {
+        method: 'GET',
+        headers: this.getHeaders(),
+        signal: AbortSignal.timeout(5000),
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Estimate cost. DashScope pricing isn't consistently published in English-
+   * language docs across regions/models, so this returns null rather than
+   * risk asserting a wrong number; override with a custom cost estimator if
+   * you need budgeting against a specific known SKU.
+   */
+  estimateCost(_request: IRChatRequest): Promise<number | null> {
+    return Promise.resolve(null);
+  }
+}

--- a/packages/backend/src/providers/github-models.ts
+++ b/packages/backend/src/providers/github-models.ts
@@ -1,0 +1,497 @@
+/**
+ * GitHub Models Backend Adapter
+ *
+ * Adapts Universal IR to GitHub Models' Chat Completions API.
+ * GitHub Models is OpenAI-compatible and free to any GitHub account (rate
+ * limits scale with Copilot subscription tier), fronting models from OpenAI,
+ * Meta, DeepSeek, Mistral, Microsoft, and Cohere.
+ *
+ * @module
+ */
+
+import type { BackendAdapter, BackendAdapterConfig, AdapterMetadata } from 'ai.matey.types';
+import type { IREmbedRequest, IREmbedResponse } from 'ai.matey.types';
+import {
+  executeOpenAICompatibleEmbed,
+  buildStructuredOutputFallbackMessages,
+  extractStructuredOutputJSON,
+  buildResponseFormatFallbackWarning,
+  buildToolsUnsupportedWarning,
+} from '../shared.js';
+import type {
+  IRChatRequest,
+  IRChatResponse,
+  IRChatStream,
+  IRMessage,
+  IRStreamChunk,
+  FinishReason,
+} from 'ai.matey.types';
+import {
+  NetworkError,
+  ProviderError,
+  StreamError,
+  ErrorCode,
+  createErrorFromHttpResponse,
+} from 'ai.matey.errors';
+import { normalizeSystemMessages } from 'ai.matey.utils';
+import { getEffectiveStreamMode, mergeStreamingConfig } from 'ai.matey.utils';
+
+// ============================================================================
+// GitHub Models API Types (OpenAI-compatible)
+// ============================================================================
+
+export type GitHubModelsMessageContent =
+  | string
+  | Array<{ type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }>;
+
+export interface GitHubModelsMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: GitHubModelsMessageContent;
+  name?: string;
+  tool_calls?: Array<{
+    id: string;
+    type: 'function';
+    function: {
+      name: string;
+      arguments: string;
+    };
+  }>;
+}
+
+export interface GitHubModelsRequest {
+  model: string;
+  messages: GitHubModelsMessage[];
+  temperature?: number;
+  max_tokens?: number;
+  top_p?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
+  stop?: string[];
+  stream?: boolean;
+}
+
+export interface GitHubModelsResponse {
+  id: string;
+  object: 'chat.completion';
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: GitHubModelsMessage;
+    finish_reason: 'stop' | 'length' | 'tool_calls' | null;
+  }>;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+export interface GitHubModelsStreamChunk {
+  id: string;
+  object: 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: {
+      role?: 'assistant';
+      content?: string;
+    };
+    finish_reason: 'stop' | 'length' | null;
+  }>;
+}
+
+// ============================================================================
+// GitHub Models Backend Adapter
+// ============================================================================
+
+/**
+ * Backend adapter for GitHub Models' Chat Completions API.
+ *
+ * Features:
+ * - Free access via any GitHub account (rate limits scale with Copilot tier)
+ * - OpenAI-compatible API (models.github.ai/inference)
+ * - Models from OpenAI, Meta, DeepSeek, Mistral, Microsoft, Cohere
+ * - Vision model support (gpt-4o, llama-3.2-vision, etc.)
+ */
+export class GitHubModelsBackendAdapter implements BackendAdapter<
+  GitHubModelsRequest,
+  GitHubModelsResponse
+> {
+  readonly metadata: AdapterMetadata;
+  private readonly config: BackendAdapterConfig;
+  private readonly baseURL: string;
+
+  constructor(config: BackendAdapterConfig) {
+    this.config = config;
+    this.baseURL = config.baseURL || 'https://models.github.ai/inference';
+    this.metadata = {
+      name: 'github-models-backend',
+      version: '1.0.0',
+      provider: 'GitHub Models',
+      capabilities: {
+        embeddings: true,
+        maxEmbeddingBatchSize: 100,
+        streaming: true,
+        multiModal: true, // gpt-4o, gpt-4.1, llama-3.2-vision, etc.
+        tools: false, // Function calling
+        structuredOutput: 'fallback',
+        maxContextTokens: 128000,
+        systemMessageStrategy: 'in-messages',
+        supportsMultipleSystemMessages: true,
+        supportsTemperature: true,
+        supportsTopP: true,
+        supportsTopK: false,
+        supportsSeed: false,
+        supportsFrequencyPenalty: true,
+        supportsPresencePenalty: true,
+        maxStopSequences: 4,
+      },
+      config: {
+        baseURL: this.baseURL,
+      },
+    };
+  }
+
+  /**
+   * Convert IR to GitHub Models format.
+   */
+  public fromIR(request: IRChatRequest): GitHubModelsRequest {
+    const { messages } = normalizeSystemMessages(
+      buildStructuredOutputFallbackMessages(request.messages, request.responseFormat),
+      this.metadata.capabilities.systemMessageStrategy,
+      this.metadata.capabilities.supportsMultipleSystemMessages
+    );
+
+    const githubMessages: GitHubModelsMessage[] = messages.map((msg) => ({
+      role: msg.role,
+      content:
+        typeof msg.content === 'string'
+          ? msg.content
+          : msg.content.map((block) => {
+              if (block.type === 'text') {
+                return { type: 'text', text: block.text };
+              } else if (block.type === 'image') {
+                return {
+                  type: 'image_url',
+                  image_url: {
+                    url:
+                      block.source.type === 'url'
+                        ? block.source.url
+                        : `data:${block.source.mediaType};base64,${block.source.data}`,
+                  },
+                };
+              }
+              return { type: 'text', text: JSON.stringify(block) };
+            }),
+    }));
+
+    return {
+      model: request.parameters?.model || this.config.defaultModel || 'openai/gpt-4o-mini',
+      messages: githubMessages,
+      temperature: request.parameters?.temperature,
+      max_tokens: request.parameters?.maxTokens,
+      top_p: request.parameters?.topP,
+      frequency_penalty: request.parameters?.frequencyPenalty,
+      presence_penalty: request.parameters?.presencePenalty,
+      stop: request.parameters?.stopSequences ? [...request.parameters.stopSequences] : undefined,
+      stream: request.stream || false,
+    };
+  }
+
+  /**
+   * Convert GitHub Models response to IR.
+   */
+  public toIR(
+    response: GitHubModelsResponse,
+    originalRequest: IRChatRequest,
+    latencyMs: number
+  ): IRChatResponse {
+    const choice = response.choices[0];
+    if (!choice) {
+      throw new ProviderError({
+        code: ErrorCode.PROVIDER_ERROR,
+        message: 'No choices returned in response',
+        isRetryable: false,
+        provenance: { backend: this.metadata.name },
+      });
+    }
+
+    const rawContent =
+      typeof choice.message.content === 'string'
+        ? choice.message.content
+        : choice.message.content.map((c: any) => (c.type === 'text' ? c.text : '')).join('');
+    const content = originalRequest.responseFormat
+      ? extractStructuredOutputJSON(rawContent)
+      : rawContent;
+    const message: IRMessage = {
+      role: choice.message.role === 'assistant' ? 'assistant' : 'user',
+      content,
+    };
+
+    const finishReasonMap: Record<string, FinishReason> = {
+      stop: 'stop',
+      length: 'length',
+      tool_calls: 'tool_calls',
+    };
+
+    const extraWarnings = [
+      ...(originalRequest.responseFormat
+        ? [buildResponseFormatFallbackWarning(this.metadata.name)]
+        : []),
+      ...(originalRequest.tools?.length ? [buildToolsUnsupportedWarning(this.metadata.name)] : []),
+    ];
+
+    return {
+      message,
+      finishReason: finishReasonMap[choice.finish_reason || 'stop'] || 'stop',
+      usage: response.usage
+        ? {
+            promptTokens: response.usage.prompt_tokens,
+            completionTokens: response.usage.completion_tokens,
+            totalTokens: response.usage.total_tokens,
+          }
+        : undefined,
+      metadata: {
+        ...originalRequest.metadata,
+        providerResponseId: response.id,
+        provenance: {
+          ...originalRequest.metadata.provenance,
+          backend: this.metadata.name,
+        },
+        custom: {
+          ...originalRequest.metadata.custom,
+          latencyMs,
+          ...(originalRequest.responseFormat ? { responseFormatEnforced: false } : {}),
+        },
+        warnings: extraWarnings.length
+          ? [...(originalRequest.metadata.warnings ?? []), ...extraWarnings]
+          : originalRequest.metadata.warnings,
+      },
+      raw: response as unknown as Record<string, unknown>,
+    };
+  }
+
+  /**
+   * Generate embeddings via the OpenAI-compatible /embeddings endpoint.
+   */
+  embed(request: IREmbedRequest, signal?: AbortSignal): Promise<IREmbedResponse> {
+    return executeOpenAICompatibleEmbed({
+      baseURL: this.baseURL,
+      headers: this.getHeaders(),
+      request,
+      backendName: this.metadata.name,
+      defaultModel: 'openai/text-embedding-3-small',
+      signal,
+    });
+  }
+
+  /**
+   * Execute non-streaming request.
+   */
+  async execute(request: IRChatRequest, signal?: AbortSignal): Promise<IRChatResponse> {
+    try {
+      const githubRequest = this.fromIR(request);
+      githubRequest.stream = false;
+
+      const startTime = Date.now();
+      const response = await fetch(`${this.baseURL}/chat/completions`, {
+        method: 'POST',
+        headers: this.getHeaders(),
+        body: JSON.stringify(githubRequest),
+        signal,
+      });
+
+      if (!response.ok) {
+        throw createErrorFromHttpResponse(
+          response.status,
+          response.statusText,
+          await response.text(),
+          { backend: this.metadata.name }
+        );
+      }
+
+      const data = (await response.json()) as GitHubModelsResponse;
+      return this.toIR(data, request, Date.now() - startTime);
+    } catch (error) {
+      if (error instanceof NetworkError || error instanceof ProviderError) {
+        throw error;
+      }
+
+      throw new ProviderError({
+        code: ErrorCode.PROVIDER_ERROR,
+        message: `GitHub Models request failed: ${error instanceof Error ? error.message : String(error)}`,
+        isRetryable: true,
+        provenance: { backend: this.metadata.name },
+        cause: error instanceof Error ? error : undefined,
+      });
+    }
+  }
+
+  /**
+   * Execute streaming request.
+   */
+  async *executeStream(request: IRChatRequest, signal?: AbortSignal): IRChatStream {
+    try {
+      const githubRequest = this.fromIR(request);
+      githubRequest.stream = true;
+
+      const streamingConfig = mergeStreamingConfig(this.config.streaming);
+      const effectiveMode = getEffectiveStreamMode(request.streamMode, undefined, streamingConfig);
+      const includeBoth = streamingConfig.includeBoth || effectiveMode === 'accumulated';
+
+      const response = await fetch(`${this.baseURL}/chat/completions`, {
+        method: 'POST',
+        headers: this.getHeaders(),
+        body: JSON.stringify(githubRequest),
+        signal,
+      });
+
+      if (!response.ok) {
+        throw createErrorFromHttpResponse(
+          response.status,
+          response.statusText,
+          await response.text(),
+          { backend: this.metadata.name }
+        );
+      }
+
+      if (!response.body) {
+        throw new StreamError({
+          code: ErrorCode.STREAM_ERROR,
+          message: 'No response body',
+          provenance: { backend: this.metadata.name },
+        });
+      }
+
+      let sequence = 0;
+      let contentBuffer = '';
+
+      yield {
+        type: 'start',
+        sequence: sequence++,
+        metadata: {
+          ...request.metadata,
+          provenance: {
+            ...request.metadata.provenance,
+            backend: this.metadata.name,
+          },
+        },
+      } as IRStreamChunk;
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() || '';
+
+          for (const line of lines) {
+            if (!line.trim() || !line.startsWith('data: ')) {
+              continue;
+            }
+
+            const data = line.slice(6).trim();
+            if (data === '[DONE]') {
+              continue;
+            }
+
+            try {
+              const chunk = JSON.parse(data) as GitHubModelsStreamChunk;
+              const delta = chunk.choices[0]?.delta?.content;
+
+              if (delta) {
+                contentBuffer += delta;
+
+                const contentChunk: IRStreamChunk = {
+                  type: 'content',
+                  sequence: sequence++,
+                  delta: delta,
+                  role: 'assistant',
+                };
+
+                if (includeBoth) {
+                  (contentChunk as any).accumulated = contentBuffer;
+                }
+
+                yield contentChunk;
+              }
+
+              if (chunk.choices[0]?.finish_reason) {
+                const finishReasonMap: Record<string, FinishReason> = {
+                  stop: 'stop',
+                  length: 'length',
+                };
+
+                yield {
+                  type: 'done',
+                  sequence: sequence++,
+                  finishReason: finishReasonMap[chunk.choices[0].finish_reason] || 'stop',
+                  message: { role: 'assistant', content: contentBuffer },
+                } as IRStreamChunk;
+              }
+            } catch (parseError) {
+              console.warn('Failed to parse SSE chunk:', data, parseError);
+            }
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    } catch (error) {
+      yield {
+        type: 'error',
+        sequence: 0,
+        error: {
+          code: error instanceof Error ? error.name : 'UNKNOWN_ERROR',
+          message: error instanceof Error ? error.message : String(error),
+        },
+      } as IRStreamChunk;
+    }
+  }
+
+  /**
+   * Get HTTP headers.
+   */
+  private getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.config.apiKey}`,
+    };
+
+    return { ...headers, ...this.config.headers };
+  }
+
+  /**
+   * Health check. Hits the public (unauthenticated) model catalog rather than
+   * `/chat/completions`, which has no cheap no-op request shape to send.
+   */
+  async healthCheck(): Promise<boolean> {
+    try {
+      const response = await fetch('https://models.github.ai/catalog/models', {
+        method: 'GET',
+        signal: AbortSignal.timeout(5000),
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Estimate cost. GitHub Models is free — usage counts against the caller's
+   * Copilot subscription rate limits, not per-token billing.
+   */
+  estimateCost(_request: IRChatRequest): Promise<number | null> {
+    return Promise.resolve(null);
+  }
+}

--- a/tests/unit/backend-adapters.test.ts
+++ b/tests/unit/backend-adapters.test.ts
@@ -7,6 +7,8 @@ import {
   InceptionBackendAdapter,
   MoonshotBackendAdapter,
   SambaNovaBackendAdapter,
+  GitHubModelsBackendAdapter,
+  DashScopeBackendAdapter,
 } from 'ai.matey.backend';
 import {
   MockBackendAdapter,
@@ -232,6 +234,94 @@ describe('Backend Adapters', () => {
       });
 
       expect(adapter).toBeDefined();
+    });
+  });
+
+  describe('GitHubModelsBackendAdapter', () => {
+    it('should create adapter with config', () => {
+      const adapter = new GitHubModelsBackendAdapter({
+        apiKey: 'test-key',
+      });
+
+      expect(adapter).toBeDefined();
+      expect(adapter.metadata.name).toBe('github-models-backend');
+    });
+
+    it('should provide metadata', () => {
+      const adapter = new GitHubModelsBackendAdapter({ apiKey: 'test-key' });
+      const metadata = adapter.metadata;
+
+      expect(metadata.name).toBe('github-models-backend');
+      expect(metadata.provider).toBe('GitHub Models');
+      expect(metadata.capabilities.streaming).toBe(true);
+      expect(metadata.capabilities.tools).toBe(false);
+      expect(metadata.capabilities.multiModal).toBe(true);
+    });
+
+    it('should use default base URL', () => {
+      const adapter = new GitHubModelsBackendAdapter({ apiKey: 'test-key' });
+
+      expect(adapter.metadata.config?.baseURL).toBe('https://models.github.ai/inference');
+    });
+
+    it('should accept custom base URL', () => {
+      const adapter = new GitHubModelsBackendAdapter({
+        apiKey: 'test-key',
+        baseURL: 'https://custom.github-models.api/inference',
+      });
+
+      expect(adapter).toBeDefined();
+    });
+
+    it('estimateCost returns null (free via Copilot subscription tier)', async () => {
+      const adapter = new GitHubModelsBackendAdapter({ apiKey: 'test-key' });
+
+      await expect(adapter.estimateCost(mockRequest)).resolves.toBeNull();
+    });
+  });
+
+  describe('DashScopeBackendAdapter', () => {
+    it('should create adapter with config', () => {
+      const adapter = new DashScopeBackendAdapter({
+        apiKey: 'test-key',
+      });
+
+      expect(adapter).toBeDefined();
+      expect(adapter.metadata.name).toBe('dashscope-backend');
+    });
+
+    it('should provide metadata', () => {
+      const adapter = new DashScopeBackendAdapter({ apiKey: 'test-key' });
+      const metadata = adapter.metadata;
+
+      expect(metadata.name).toBe('dashscope-backend');
+      expect(metadata.provider).toBe('Alibaba Cloud Model Studio (DashScope)');
+      expect(metadata.capabilities.streaming).toBe(true);
+      expect(metadata.capabilities.tools).toBe(false);
+      expect(metadata.capabilities.multiModal).toBe(true);
+    });
+
+    it('should use default (international) base URL', () => {
+      const adapter = new DashScopeBackendAdapter({ apiKey: 'test-key' });
+
+      expect(adapter.metadata.config?.baseURL).toBe(
+        'https://dashscope-intl.aliyuncs.com/compatible-mode/v1'
+      );
+    });
+
+    it('should accept custom base URL (e.g. mainland China region)', () => {
+      const adapter = new DashScopeBackendAdapter({
+        apiKey: 'test-key',
+        baseURL: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+      });
+
+      expect(adapter).toBeDefined();
+    });
+
+    it('estimateCost returns null (pricing not consistently published)', async () => {
+      const adapter = new DashScopeBackendAdapter({ apiKey: 'test-key' });
+
+      await expect(adapter.estimateCost(mockRequest)).resolves.toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- New `GitHubModelsBackendAdapter` — free OpenAI-compatible gateway via any GitHub account, fronting OpenAI/Meta/DeepSeek/Mistral/Microsoft models (`models.github.ai/inference`)
- New `DashScopeBackendAdapter` — Alibaba Cloud Model Studio's OpenAI-compatible mode for the Qwen model family (`dashscope-intl.aliyuncs.com/compatible-mode/v1`)
- Both follow the existing together-ai/fireworks passthrough pattern: `structuredOutput: 'fallback'`, `tools: false` + warning (no native tool-call mapping implemented for either), `estimateCost()` returns `null` (no reliable per-token pricing for either — GitHub Models is Copilot-quota-metered, not billed; DashScope pricing isn't consistently published across regions in English docs)
- Registered in `packages/backend/src/index.ts`, package.json subpath exports, readme provider table, `docs/ROADMAP.md`/`docs/IR-FORMAT.md`
- Minor changeset for `ai.matey.backend`

## Test plan
- [x] `tests/unit/backend-adapters.test.ts` — 10 new tests (construction, metadata, default/custom baseURL, estimateCost) for both adapters, 71/71 passing
- [x] Full suite: 1507 passed / 11 skipped, 0 failures
- [x] `npx turbo run build` clean across the workspace
- [x] `npx turbo run lint --filter=ai.matey.backend` — 0 errors (443 pre-existing warnings, same pattern shared by every sibling adapter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)