### PR TITLE
Fix docs discoverability for ai.matey.mcp and recent providers

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -11,6 +11,7 @@ Complete working examples demonstrating all features of ai.matey, the Universal 
 - [Routing](#routing)
 - [HTTP Servers](#http-servers)
 - [SDK Wrappers](#sdk-wrappers)
+- [Tool Calling](#tool-calling)
 - [Browser APIs](#browser-apis)
 - [Model Runners](#model-runners)
 - [Advanced Patterns](#advanced-patterns)
@@ -205,6 +206,85 @@ async function main() {
 **Run:**
 ```bash
 npx tsx examples/basic/reverse-bridge.ts
+```
+
+---
+
+### 4. GitHub Models (`basic/github-models.ts`)
+
+Free access to OpenAI, Meta, DeepSeek, Mistral, and Microsoft models via any GitHub account.
+
+**What it demonstrates:**
+- Using a free, OpenAI-compatible gateway (no billing account needed)
+- `publisher/model-name` model IDs (e.g. `openai/gpt-4o-mini`)
+
+**Code:**
+
+```typescript
+import { Bridge } from 'ai.matey.core';
+import { OpenAIFrontendAdapter } from 'ai.matey.frontend/openai';
+import { GitHubModelsBackendAdapter } from 'ai.matey.backend/github-models';
+
+async function main() {
+  const bridge = new Bridge(
+    new OpenAIFrontendAdapter(),
+    new GitHubModelsBackendAdapter({
+      apiKey: process.env.GITHUB_TOKEN || 'ghp_...',
+    })
+  );
+
+  const response = await bridge.chat({
+    model: 'openai/gpt-4o-mini', // see https://models.github.ai/catalog/models
+    messages: [{ role: 'user', content: 'What is the capital of France?' }],
+  });
+
+  console.log('Response:', response);
+}
+```
+
+**Run:**
+```bash
+npx tsx examples/basic/github-models.ts
+```
+
+---
+
+### 5. DashScope / Alibaba Cloud Model Studio (`basic/dashscope.ts`)
+
+The Qwen model family via DashScope's OpenAI-compatible mode.
+
+**What it demonstrates:**
+- Using a non-Western cloud provider's OpenAI-compatible endpoint
+- Overriding `baseURL` for a regional deployment (mainland China vs. international)
+
+**Code:**
+
+```typescript
+import { Bridge } from 'ai.matey.core';
+import { OpenAIFrontendAdapter } from 'ai.matey.frontend/openai';
+import { DashScopeBackendAdapter } from 'ai.matey.backend/dashscope';
+
+async function main() {
+  const bridge = new Bridge(
+    new OpenAIFrontendAdapter(),
+    new DashScopeBackendAdapter({
+      apiKey: process.env.DASHSCOPE_API_KEY || 'sk-...',
+      // baseURL: 'https://dashscope.aliyuncs.com/compatible-mode/v1', // mainland China
+    })
+  );
+
+  const response = await bridge.chat({
+    model: 'qwen3.7-plus',
+    messages: [{ role: 'user', content: 'What is the capital of France?' }],
+  });
+
+  console.log('Response:', response);
+}
+```
+
+**Run:**
+```bash
+npx tsx examples/basic/dashscope.ts
 ```
 
 ---
@@ -1538,6 +1618,37 @@ Drop-in replacement for Anthropic SDK - use any backend!
 **Run:**
 ```bash
 npx tsx examples/wrappers/anthropic-sdk.ts
+```
+
+---
+
+## Tool Calling
+
+### Agentic Tool-Call Loop (`tools/run-tools.ts`)
+
+`Bridge.runTools()` - execute → extract tool calls → run them → append results →
+re-execute, looping until the model answers or `maxIterations` is hit.
+
+**Run:**
+```bash
+npx tsx examples/tools/run-tools.ts
+```
+
+### MCP (Model Context Protocol) (`ai.matey.mcp`)
+
+The [`ai.matey.mcp`](./packages/mcp/readme.md) package translates MCP tools into the
+`ToolDefinition` shape `runTools()` already consumes, via an injectable `McpClientLike`
+client - no hard dependency on any MCP SDK. Works with the official
+`@modelcontextprotocol/sdk`, [`mcp-query`](https://github.com/johnhenry/mcp-query), or a
+test fake; see the package readme for `mcpToolsToDefinitions()` and `runMcpTools()` examples.
+
+```typescript
+import { runMcpTools } from 'ai.matey.mcp';
+
+const result = await runMcpTools(bridge.runTools, {
+  client: mcpClient, // any McpClientLike - e.g. an mcp-query MCPClient
+  prompt: 'What files changed in the last commit?',
+});
 ```
 
 ---

--- a/examples/basic/dashscope.ts
+++ b/examples/basic/dashscope.ts
@@ -1,0 +1,39 @@
+/**
+ * DashScope (Alibaba Cloud Model Studio) Example
+ *
+ * DashScope's OpenAI-compatible mode fronts the Qwen model family. This uses
+ * the international (Singapore) endpoint by default; override `baseURL` for
+ * a mainland China deployment.
+ *
+ * Auth: a Model Studio API key.
+ * https://www.alibabacloud.com/help/en/model-studio/get-api-key
+ */
+
+import { Bridge } from 'ai.matey.core';
+import { OpenAIFrontendAdapter } from 'ai.matey.frontend/openai';
+import { DashScopeBackendAdapter } from 'ai.matey.backend/dashscope';
+
+async function main() {
+  const bridge = new Bridge(
+    new OpenAIFrontendAdapter(),
+    new DashScopeBackendAdapter({
+      apiKey: process.env.DASHSCOPE_API_KEY || 'sk-...',
+    })
+  );
+
+  const response = await bridge.chat({
+    // The OpenAI frontend forwards `model` verbatim, so pass a real Qwen
+    // model ID directly rather than relying on the adapter's defaultModel.
+    model: 'qwen3.7-plus',
+    messages: [
+      {
+        role: 'user',
+        content: 'What is the capital of France?',
+      },
+    ],
+  });
+
+  console.log('Response:', response);
+}
+
+main().catch(console.error);

--- a/examples/basic/github-models.ts
+++ b/examples/basic/github-models.ts
@@ -1,0 +1,41 @@
+/**
+ * GitHub Models Example
+ *
+ * GitHub Models is free to any GitHub account (rate limits scale with your
+ * Copilot subscription tier) and fronts models from OpenAI, Meta, DeepSeek,
+ * Mistral, and Microsoft behind one OpenAI-compatible API.
+ *
+ * Auth: a GitHub personal access token with the `models: read` permission.
+ * https://github.com/settings/tokens
+ */
+
+import { Bridge } from 'ai.matey.core';
+import { OpenAIFrontendAdapter } from 'ai.matey.frontend/openai';
+import { GitHubModelsBackendAdapter } from 'ai.matey.backend/github-models';
+
+async function main() {
+  const bridge = new Bridge(
+    new OpenAIFrontendAdapter(),
+    new GitHubModelsBackendAdapter({
+      apiKey: process.env.GITHUB_TOKEN || 'ghp_...',
+    })
+  );
+
+  const response = await bridge.chat({
+    // GitHub Models uses `publisher/model-name` IDs - the OpenAI frontend
+    // forwards `model` verbatim, so pass a real catalog ID directly rather
+    // than relying on the adapter's defaultModel (see
+    // https://models.github.ai/catalog/models for the full list).
+    model: 'openai/gpt-4o-mini',
+    messages: [
+      {
+        role: 'user',
+        content: 'What is the capital of France?',
+      },
+    ],
+  });
+
+  console.log('Response:', response);
+}
+
+main().catch(console.error);

--- a/readme.md
+++ b/readme.md
@@ -419,6 +419,11 @@ import { OpenAIBackendAdapter } from 'ai.matey.backend/openai';
 - Hugging Face
 - Cloudflare Workers AI
 - Replicate
+- Inception Labs (Mercury)
+- Moonshot AI (Kimi)
+- SambaNova
+- GitHub Models (free via any GitHub account)
+- Alibaba Cloud Model Studio / DashScope (Qwen)
 
 **Browser-Compatible Package:** [`ai.matey.backend.browser`](./packages/backend-browser)
 
@@ -512,6 +517,24 @@ import { OpenAI } from 'ai.matey.wrapper';  // OpenAI SDK-compatible
 - Chrome AI API
 - IR-native chat client
 - Dynamic wrapper (anymethod)
+
+### Tool Calling (MCP)
+
+**Package:** [`ai.matey.mcp`](./packages/mcp) | [📚 Documentation](./packages/mcp/readme.md)
+
+Translates MCP (Model Context Protocol) tools into the `ToolDefinition` shape consumed by
+`ai.matey.core`'s `Bridge.runTools()` agentic loop, via an injectable client - no hard
+dependency on any MCP SDK. Works with the official `@modelcontextprotocol/sdk`,
+[`mcp-query`](https://github.com/johnhenry/mcp-query), or a test fake.
+
+```typescript
+import { runMcpTools } from 'ai.matey.mcp';
+
+const result = await runMcpTools(bridge.runTools, {
+  client: mcpClient, // any object satisfying McpClientLike
+  prompt: 'What files changed in the last commit?',
+});
+```
 
 ### Native Backends
 


### PR DESCRIPTION
## Summary
- Adds a "Tool Calling (MCP)" section to the root readme's Package Reference, linking `ai.matey.mcp` (previously unlinked from root docs) and showing a `runMcpTools()` snippet
- Adds a "Tool Calling" section to `EXAMPLES.md` covering both the existing (previously unindexed) `tools/run-tools.ts` and `ai.matey.mcp`
- Adds `examples/basic/github-models.ts` and `examples/basic/dashscope.ts` — runnable examples for the two providers added in #27, following the existing `basic/simple-bridge.ts` pattern
- Fixes the root readme's stale backend-provider bullet list (missing Inception Labs/Moonshot AI/SambaNova from an earlier addition, plus the two newest providers)

No source code changes — docs and examples only.

## Test plan
- [x] Both new example files typecheck clean (`tsc --noEmit --strict`) against the workspace packages
- [x] Verified the "OpenAI frontend forwards `model` verbatim" behavior in `packages/frontend/src/adapters/openai.ts` before writing the examples, so they pass real provider-specific model IDs rather than relying on a `defaultModel` fallback that wouldn't actually trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)