### PR TITLE
Fix documentation staleness for recent release candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Structured/schema-constrained output: `responseFormat` on `IRChatRequest`, with native
+  mapping for OpenAI/Anthropic/Gemini and best-effort prompt-injection fallback for every
+  other backend
+- New package `ai.matey.mcp`: MCP (Model Context Protocol) tool-calling via an injectable
+  `McpClientLike` client (no hard dependency on any MCP SDK) - see `packages/mcp/readme.md`
+- Five new backend provider adapters: Inception Labs (Mercury), Moonshot AI (Kimi), SambaNova,
+  GitHub Models (free via any GitHub account), and DashScope / Alibaba Cloud Model Studio (Qwen)
+- Default model bumps across several adapters (OpenAI, Anthropic, Gemini, xAI, Moonshot,
+  OpenRouter) to their current-generation flagships
+
+### Fixed
+- CJS packaging: every package now writes a `dist/cjs/package.json` marker
+  (`{"type":"commonjs"}`) after build, fixing `require()` resolution that broke under
+  each package's root `"type":"module"`
+- Anthropic: omit `temperature`/`top_p`/`top_k` for Claude Opus 4.7+/Sonnet 5, which return
+  HTTP 400 if these sampling params are set to non-default values
+
 ### Changed
 - **BREAKING**: Renamed package `ai.matey.http-core` to `ai.matey.http.core` for naming consistency with other multi-word packages
 - Removed deprecated root-level `src/` directory (all code now in `packages/`)

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -292,7 +292,7 @@ npx tsx examples/basic/dashscope.ts
 
 ## Structured Output
 
-### Schema-Constrained JSON Output (`basic/structured-output.ts`)
+### 6. Schema-Constrained JSON Output (`basic/structured-output.ts`)
 
 Request JSON output that conforms to a schema, via `responseFormat` on `IRChatRequest`.
 
@@ -347,7 +347,7 @@ support matrix.
 
 ## Middleware
 
-### 4. Logging Middleware (`middleware/logging.ts`)
+### 7. Logging Middleware (`middleware/logging.ts`)
 
 Add logging to track requests and responses for debugging and monitoring.
 
@@ -406,7 +406,7 @@ npx tsx examples/middleware/logging.ts
 
 ---
 
-### 5. Retry Middleware (`middleware/retry.ts`)
+### 8. Retry Middleware (`middleware/retry.ts`)
 
 Automatic retry logic for failed requests with exponential backoff.
 
@@ -477,7 +477,7 @@ npx tsx examples/middleware/retry.ts
 
 ---
 
-### 6. Caching Middleware (`middleware/caching.ts`)
+### 9. Caching Middleware (`middleware/caching.ts`)
 
 Cache responses to reduce API calls and costs.
 
@@ -553,7 +553,7 @@ npx tsx examples/middleware/caching.ts
 
 ---
 
-### 7. Transform Middleware (`middleware/transform.ts`)
+### 10. Transform Middleware (`middleware/transform.ts`)
 
 Transform requests and responses (e.g., inject system messages).
 
@@ -611,7 +611,7 @@ npx tsx examples/middleware/transform.ts
 
 ---
 
-### 8. Middleware Chaining (`middleware-demo.ts`)
+### 11. Middleware Chaining (`middleware-demo.ts`)
 
 Demonstrates chaining multiple middleware together for powerful request/response processing.
 
@@ -630,7 +630,7 @@ npx tsx examples/middleware-demo.ts
 
 ## Routing
 
-### 9. Round-Robin Router (`routing/round-robin.ts`)
+### 12. Round-Robin Router (`routing/round-robin.ts`)
 
 Distribute requests across multiple backends for load balancing.
 
@@ -697,7 +697,7 @@ npx tsx examples/routing/round-robin.ts
 
 ---
 
-### 10. Fallback Router (`routing/fallback.ts`)
+### 13. Fallback Router (`routing/fallback.ts`)
 
 Automatic failover to backup backends when primary fails.
 
@@ -767,7 +767,7 @@ npx tsx examples/routing/fallback.ts
 
 ---
 
-### 11. Router with Model Translation (`routing/model-translation.ts`)
+### 14. Router with Model Translation (`routing/model-translation.ts`)
 
 Automatic model name translation during fallback for cross-provider compatibility.
 
@@ -888,7 +888,7 @@ npx tsx examples/routing/model-translation.ts
 
 ---
 
-### 12. Router with Per-Backend Translation (`routing/per-backend-translation.ts`)
+### 15. Router with Per-Backend Translation (`routing/per-backend-translation.ts`)
 
 Backend-specific model translation mappings that override global translations.
 
@@ -999,7 +999,7 @@ npx tsx examples/routing/per-backend-translation.ts
 
 ---
 
-### 13. Capability-Based Routing (`routing/capability-based.ts`)
+### 16. Capability-Based Routing (`routing/capability-based.ts`)
 
 Automatically select backends based on model capabilities and requirements.
 
@@ -1092,7 +1092,7 @@ npx tsx examples/routing/capability-based.ts
 
 ---
 
-### 14. Cost-Optimized Routing (`routing/cost-optimized.ts`)
+### 17. Cost-Optimized Routing (`routing/cost-optimized.ts`)
 
 Automatically route to the cheapest backend that meets requirements.
 
@@ -1195,7 +1195,7 @@ npx tsx examples/routing/cost-optimized.ts
 
 ---
 
-### 15. Speed-Optimized Routing (`routing/speed-optimized.ts`)
+### 18. Speed-Optimized Routing (`routing/speed-optimized.ts`)
 
 Route to the fastest backend for low-latency applications.
 
@@ -1306,7 +1306,7 @@ npx tsx examples/routing/speed-optimized.ts
 
 ---
 
-### 16. Quality-Optimized Routing (`routing/quality-optimized.ts`)
+### 19. Quality-Optimized Routing (`routing/quality-optimized.ts`)
 
 Route to the highest quality models for critical tasks.
 
@@ -1419,7 +1419,7 @@ npx tsx examples/routing/quality-optimized.ts
 
 ## HTTP Servers
 
-### 13. Node.js HTTP Server (`http/node-server.ts`)
+### 20. Node.js HTTP Server (`http/node-server.ts`)
 
 Create a basic HTTP server using Node.js http module.
 
@@ -1498,7 +1498,7 @@ npx tsx examples/http/node-server.ts
 
 ---
 
-### 12. Express Server (`http/express-server.ts`)
+### 21. Express Server (`http/express-server.ts`)
 
 HTTP server using Express framework.
 
@@ -1559,7 +1559,7 @@ npx tsx examples/http/express-server.ts
 
 ---
 
-### 13. Hono Server (`http/hono-server.ts`)
+### 22. Hono Server (`http/hono-server.ts`)
 
 Lightweight HTTP server using Hono framework.
 
@@ -1577,7 +1577,7 @@ npx tsx examples/http/hono-server.ts
 
 ## SDK Wrappers
 
-### 14. OpenAI SDK Wrapper (`wrappers/openai-sdk.ts`)
+### 23. OpenAI SDK Wrapper (`wrappers/openai-sdk.ts`)
 
 Drop-in replacement for OpenAI SDK - use any backend!
 
@@ -1662,7 +1662,7 @@ npx tsx examples/wrappers/openai-sdk.ts
 
 ---
 
-### 15. Anthropic SDK Wrapper (`wrappers/anthropic-sdk.ts`)
+### 24. Anthropic SDK Wrapper (`wrappers/anthropic-sdk.ts`)
 
 Drop-in replacement for Anthropic SDK - use any backend!
 
@@ -1680,7 +1680,7 @@ npx tsx examples/wrappers/anthropic-sdk.ts
 
 ## Tool Calling
 
-### Agentic Tool-Call Loop (`tools/run-tools.ts`)
+### 25. Agentic Tool-Call Loop (`tools/run-tools.ts`)
 
 `Bridge.runTools()` - execute → extract tool calls → run them → append results →
 re-execute, looping until the model answers or `maxIterations` is hit.
@@ -1711,7 +1711,7 @@ const result = await runMcpTools(bridge.runTools, {
 
 ## Browser APIs
 
-### 16. Chrome AI Language Model (`chrome-ai-wrapper.js`)
+### 26. Chrome AI Language Model (`chrome-ai-wrapper.js`)
 
 Mimic the Chrome AI API with any backend adapter.
 
@@ -1737,7 +1737,7 @@ node examples/chrome-ai-wrapper.js
 
 ---
 
-### 17. Legacy Chrome AI Wrapper (`chrome-ai-legacy-wrapper.js`)
+### 27. Legacy Chrome AI Wrapper (`chrome-ai-legacy-wrapper.js`)
 
 Support for the legacy Chrome AI API (pre-recent changes).
 
@@ -1764,7 +1764,7 @@ node examples/chrome-ai-legacy-wrapper.js
 
 ## Model Runners
 
-### 18. LlamaCpp Backend (`model-runner-llamacpp.ts`)
+### 28. LlamaCpp Backend (`model-runner-llamacpp.ts`)
 
 Run local GGUF models via llama.cpp binaries.
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -7,6 +7,7 @@ Complete working examples demonstrating all features of ai.matey, the Universal 
 - [Running Examples](#running-examples)
 - [Environment Setup](#environment-setup)
 - [Basic Usage](#basic-usage)
+- [Structured Output](#structured-output)
 - [Middleware](#middleware)
 - [Routing](#routing)
 - [HTTP Servers](#http-servers)
@@ -286,6 +287,61 @@ async function main() {
 ```bash
 npx tsx examples/basic/dashscope.ts
 ```
+
+---
+
+## Structured Output
+
+### Schema-Constrained JSON Output (`basic/structured-output.ts`)
+
+Request JSON output that conforms to a schema, via `responseFormat` on `IRChatRequest`.
+
+**What it demonstrates:**
+- Native mapping for OpenAI/Anthropic/Gemini, prompt-injection fallback for everyone else
+- `bridge.executeIR()` — passing an `IRChatRequest` directly, since `responseFormat` is an
+  IR-level field none of the client-facing frontend formats currently translate
+
+**Code:**
+
+```typescript
+import { Bridge } from 'ai.matey.core';
+import { OpenAIFrontendAdapter } from 'ai.matey.frontend/openai';
+import { AnthropicBackendAdapter } from 'ai.matey.backend/anthropic';
+
+async function main() {
+  const bridge = new Bridge(
+    new OpenAIFrontendAdapter(),
+    new AnthropicBackendAdapter({
+      apiKey: process.env.ANTHROPIC_API_KEY || 'sk-ant-...',
+    })
+  );
+
+  const response = await bridge.executeIR({
+    messages: [{ role: 'user', content: 'Extract the name and age from: John is 30.' }],
+    responseFormat: {
+      type: 'json_schema',
+      schema: {
+        type: 'object',
+        properties: { name: { type: 'string' }, age: { type: 'number' } },
+        required: ['name', 'age'],
+      },
+    },
+    parameters: { model: 'claude-sonnet-5' },
+    metadata: { requestId: 'req_1', timestamp: Date.now(), provenance: { frontend: 'openai' } },
+  });
+
+  console.log('Response:', response);
+  // response.message.content -> '{"name":"John","age":30}'
+}
+```
+
+**Run:**
+```bash
+npx tsx examples/basic/structured-output.ts
+```
+
+See [`docs/IR-FORMAT.md`](./docs/IR-FORMAT.md#structured-output) for the full per-backend
+support matrix.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,9 +5,9 @@ Development roadmap and strategic direction for the Universal AI Adapter System.
 ## Architecture Overview
 
 **Monorepo Structure:**
-- 21 consolidated packages
-- 165 TypeScript source files
-- 32,019 lines of TypeScript code
+- 24 consolidated packages
+- 194 TypeScript source files
+- ~60,500 lines of TypeScript code
 - Turbo-based build system with caching
 - Dual-format distribution: ESM and CommonJS
 - Full TypeScript declarations
@@ -23,8 +23,8 @@ Development roadmap and strategic direction for the Universal AI Adapter System.
 - ✅ Provider-agnostic request/response handling
 
 ### Providers
-- ✅ **26 Backend Providers** in `ai.matey.backend`:
-  OpenAI, Anthropic, Gemini, Mistral, Cohere, Groq, Ollama, AI21, Anyscale, AWS Bedrock, Azure OpenAI, Cerebras, Cloudflare, DeepInfra, DeepSeek, Fireworks, HuggingFace, LMStudio, NVIDIA, OpenRouter, Perplexity, Replicate, Together AI, XAI, GitHub Models, DashScope (Alibaba Cloud Model Studio)
+- ✅ **29 Backend Providers** in `ai.matey.backend`:
+  OpenAI, Anthropic, Gemini, Mistral, Cohere, Groq, Ollama, AI21, Anyscale, AWS Bedrock, Azure OpenAI, Cerebras, Cloudflare, DeepInfra, DeepSeek, Fireworks, HuggingFace, LMStudio, NVIDIA, OpenRouter, Perplexity, Replicate, Together AI, XAI, Inception Labs, Moonshot AI, SambaNova, GitHub Models, DashScope (Alibaba Cloud Model Studio)
 - ✅ **7 Frontend Adapters** in `ai.matey.frontend`:
   OpenAI, Anthropic, Gemini, Mistral, Ollama, Chrome AI, Generic
 - ✅ **3 Browser Backends** in `ai.matey.backend.browser`:
@@ -105,7 +105,7 @@ All 10 middleware types in `ai.matey.middleware`:
 - `ai.matey.core` - Bridge, Router, Middleware core
 
 ### Providers (3 packages)
-- `ai.matey.backend` - All 24 backend provider adapters
+- `ai.matey.backend` - All 29 backend provider adapters
 - `ai.matey.backend.browser` - Browser-only backends
 - `ai.matey.frontend` - All 7 frontend adapters
 
@@ -435,14 +435,24 @@ MediaPipe genai API is maintenance-mode.)
 
 ### Wave 1 (next): MCP + Agents
 
-**MCP client + server — new package `ai.matey.mcp`** (`packages/mcp`; optional peer
-`@modelcontextprotocol/sdk`):
-- Client: `createMCPToolSet({ transport: stdio | streamableHttp, oauth?, namePrefix?, include? })`
-  → `{ tools: Record<string, ToolDefinition>, listResources/readResource, listPrompts/getPrompt
-  (→ IRMessage[]), refreshTools, close }`. MCP tool `inputSchema` passes straight through to
-  `IRTool.parameters` (both raw JSON Schema); `tools/call` isError results throw so the existing
-  runTools loop feeds them back as error tool results. Tools plug into `bridge.runTools`/Agent
-  with zero loop changes.
+**MCP client — shipped as `ai.matey.mcp`** (`packages/mcp`, 2026-07-23; depends only on
+`ai.matey.types`, no MCP SDK dependency at all — the final design diverged from the original
+optional-peer-SDK plan below in favor of a purely structural `McpClientLike` interface, so any
+client implementation (the official SDK wrapped by hand, [`mcp-query`](https://github.com/johnhenry/mcp-query),
+or a test fake) works with zero adapter code):
+- `mcpToolsToDefinitions(client, opts?)` → `Record<string, ToolDefinition>`. MCP tool
+  `inputSchema` passes straight through to `IRTool.parameters` (both raw JSON Schema);
+  `isError` results throw so the existing `runTools` loop feeds them back as error tool results.
+- `runMcpTools(runTools, { client, ...RunToolsOptions })` composes the above with an
+  already-bound `runTools` function (e.g. `bridge.runTools`) — zero loop changes needed.
+- Protocol-version-agnostic by design: `ai.matey.mcp` never touches the wire protocol, so
+  whichever MCP revision(s) the injected client negotiates are supported transparently. See
+  `packages/mcp/readme.md`'s "Protocol Versions" section.
+
+**MCP server — not yet built.** The original plan below (`createMCPServer` on the SDK's
+low-level `Server`, v1 tools-only / v2 resources+prompts) is still the intended shape for
+exposing an ai.matey `Bridge` as an MCP server; tracked separately, not part of the client work
+above.
 - Server: `createMCPServer({ name, tools, bridge? })` on the SDK's **low-level Server**
   (`setRequestHandler` with raw JSON Schema — avoids a zod dependency), reusing
   `validateToolArgs`; `connectStdio()` plus Streamable HTTP `nodeHandler()`/`genericHandler()`
@@ -512,7 +522,7 @@ only via a structural `EmbeddingProvider = { embed() }`):
 
 ### Durable strengths to preserve
 
-Zero runtime dependencies; 28 backends with 7 routing strategies, circuit breaker, fallback and
+Zero runtime dependencies; 29 backends with 7 routing strategies, circuit breaker, fallback and
 parallel dispatch; 6 HTTP framework adapters with health/metrics/embeddings endpoints; the
 format-conversion CLI and OpenAI/Anthropic SDK shims; multi-format frontend adapters (few
 competitors can speak Anthropic's or Gemini's wire format into the same core).

--- a/examples/basic/structured-output.ts
+++ b/examples/basic/structured-output.ts
@@ -1,0 +1,58 @@
+/**
+ * Structured Output Example
+ *
+ * Request schema-constrained JSON output via `responseFormat`. OpenAI,
+ * Anthropic, and Gemini map this to their native structured-output
+ * mechanisms; every other backend falls back to prompt injection + JSON
+ * extraction. See docs/IR-FORMAT.md#structured-output for the full matrix.
+ *
+ * `responseFormat` is an IR-level field - none of the client-facing frontend
+ * formats (OpenAI, Anthropic, ...) currently translate their own
+ * structured-output syntax into it, so this uses `bridge.executeIR()` to pass
+ * an `IRChatRequest` straight through, bypassing frontend translation.
+ */
+
+import { Bridge } from 'ai.matey.core';
+import { OpenAIFrontendAdapter } from 'ai.matey.frontend/openai';
+import { AnthropicBackendAdapter } from 'ai.matey.backend/anthropic';
+
+async function main() {
+  const bridge = new Bridge(
+    new OpenAIFrontendAdapter(),
+    new AnthropicBackendAdapter({
+      apiKey: process.env.ANTHROPIC_API_KEY || 'sk-ant-...',
+    })
+  );
+
+  const response = await bridge.executeIR({
+    messages: [
+      {
+        role: 'user',
+        content: 'Extract the name and age from: John is 30.',
+      },
+    ],
+    responseFormat: {
+      type: 'json_schema',
+      schema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+        },
+        required: ['name', 'age'],
+      },
+    },
+    parameters: { model: 'claude-sonnet-5' },
+    metadata: {
+      requestId: 'req_1',
+      timestamp: Date.now(),
+      provenance: { frontend: 'openai' },
+    },
+  });
+
+  console.log('Response:', response);
+  // response.message.content -> '{"name":"John","age":30}'
+  // response.metadata.custom.responseFormatEnforced -> true (native) or false (fallback)
+}
+
+main().catch(console.error);

--- a/packages/ai.matey.core/readme.md
+++ b/packages/ai.matey.core/readme.md
@@ -18,12 +18,42 @@ npm install ai.matey.core
 - `createRouter`
 - `MiddlewareStack`
 - `createMiddlewareContext`
+- `createRunTools`, `RunToolsBridge` (type)
 
 ## Usage
 
 ```typescript
 import { Bridge, createBridge, Router, createRouter, MiddlewareStack, createMiddlewareContext } from 'ai.matey.core';
 ```
+
+## Structured Output
+
+`Bridge.chat()`/`chatStream()` accept a `responseFormat` field on the request for
+schema-constrained JSON output - see [`docs/IR-FORMAT.md`](../../docs/IR-FORMAT.md#structured-output)
+for the per-backend support matrix.
+
+## Agentic Tool Calling
+
+Every `Bridge` instance exposes `bridge.runTools(options)` (built from `createRunTools`) - an
+execute → extract tool calls → run them → append results → re-execute loop that continues until
+the model answers or `maxIterations` is reached:
+
+```typescript
+const result = await bridge.runTools({
+  prompt: 'What is 12 * 47?',
+  tools: {
+    multiply: {
+      description: 'Multiply two numbers',
+      parameters: { type: 'object', properties: { a: { type: 'number' }, b: { type: 'number' } } },
+      execute: ({ a, b }) => a * b,
+    },
+  },
+});
+```
+
+For MCP (Model Context Protocol) tools specifically, see
+[`ai.matey.mcp`](../mcp/readme.md), which translates MCP tools into the same `ToolDefinition`
+shape this loop consumes.
 
 ## API Reference
 

--- a/packages/ai.matey.types/readme.md
+++ b/packages/ai.matey.types/readme.md
@@ -21,6 +21,8 @@ npm install ai.matey.types
 - `IRMetadata` - Request/response metadata and provenance
 - `IRTool` - Tool/function definition
 - `IRUsage` - Token usage statistics
+- `IRResponseFormat` - Schema-constrained (structured) output request
+- `ToolDefinition`, `RunToolsOptions`, `RunToolsResult` - agentic tool-calling loop types
 
 ### Adapter Interfaces
 - `FrontendAdapter` - Interface for frontend adapters
@@ -70,13 +72,26 @@ const request: IRChatRequest = {
     provenance: { frontend: 'openai' }
   }
 };
+
+// Request schema-constrained (structured) output
+const structuredRequest: IRChatRequest = {
+  ...request,
+  responseFormat: {
+    type: 'json_schema',
+    schema: {
+      type: 'object',
+      properties: { answer: { type: 'string' } },
+      required: ['answer'],
+    },
+  },
+};
 ```
 
 ## Documentation
 
 For comprehensive documentation of the IR format, see:
 - [IR Format Guide](../../docs/IR-FORMAT.md) - Complete specification with examples
-- [API Reference](../../docs/API.md) - Full API documentation
+- [API Reference](../../docs/api.md) - Full API documentation
 - [Type Definitions](./src/ir.ts) - Authoritative TypeScript source
 
 ## License

--- a/packages/ai.matey.utils/readme.md
+++ b/packages/ai.matey.utils/readme.md
@@ -212,6 +212,35 @@ const readable = asyncGeneratorToReadableStream(stream);
 const generator = readableStreamToAsyncGenerator(readable);
 ```
 
+## Model Registry
+
+Single source of truth for model metadata (pricing, context windows, capabilities,
+quality/latency heuristics), seeded from a built-in `MODEL_REGISTRY_SEED` and extensible at
+runtime so consumers aren't blocked by stale built-in data:
+
+```typescript
+import { registerModels, getModelEntry, getModelPricingInfo } from 'ai.matey.utils';
+
+registerModels([
+  { id: 'gpt-6-preview', provider: 'openai', family: 'gpt-6', pricing: { inputPer1M: 2.0, outputPer1M: 16.0 } },
+]);
+
+getModelEntry('gpt-6-preview');
+getModelPricingInfo('claude-sonnet-5');
+```
+
+Lookup resolves exact ids first, then aliases, then the longest matching id/alias prefix - so
+an unrecognized dated snapshot still resolves to its family entry instead of returning nothing.
+
+## Schema & Validation Utilities
+
+`schemaToToolDefinition`, `validateWithSchema`, and PII/prompt-injection detection helpers
+(`DEFAULT_PII_PATTERNS`, `DEFAULT_INJECTION_PATTERNS`) for building and validating tool schemas.
+Note: this is separate from `IRResponseFormat`/`responseFormat` (schema-constrained *model
+output*, defined in `ai.matey.types` and mapped per-backend in `ai.matey.backend` - see
+[`docs/IR-FORMAT.md`](../../docs/IR-FORMAT.md#structured-output)); these utilities are about
+tool/function schemas and input validation instead.
+
 ## Types
 
 ```typescript

--- a/packages/backend/readme.md
+++ b/packages/backend/readme.md
@@ -15,9 +15,9 @@ npm install ai.matey.backend
 This package includes adapters for **29 AI providers**:
 
 ### Commercial APIs
-- **OpenAI** - GPT-4, GPT-4 Turbo, GPT-3.5
-- **Anthropic** - Claude 3 Opus, Claude 3 Sonnet, Claude 3 Haiku
-- **Google Gemini** - Gemini Pro, Gemini Ultra
+- **OpenAI** - GPT-5.6 family
+- **Anthropic** - Claude Sonnet 5, Claude Opus 4.7+
+- **Google Gemini** - Gemini 3.6 Flash and other current-generation Gemini models
 - **Mistral AI** - Mistral Large, Medium, Small
 - **Cohere** - Command, Command-Light, Command-R
 - **xAI** - Grok models
@@ -81,6 +81,22 @@ You can also import specific providers directly:
 import { OpenAIBackendAdapter } from 'ai.matey.backend/openai';
 import { AnthropicBackendAdapter } from 'ai.matey.backend/anthropic';
 ```
+
+## Structured Output
+
+Set `responseFormat` on an `IRChatRequest` to get schema-constrained JSON output. OpenAI,
+Anthropic, and Gemini map it to their native structured-output mechanisms
+(`response_format`/`output_config`/`responseSchema`); every other backend falls back to prompt
+injection + best-effort JSON extraction. See
+[`docs/IR-FORMAT.md`](../../docs/IR-FORMAT.md#structured-output) for the full support matrix and
+a request/response example.
+
+## Anthropic Sampling Parameters
+
+Claude Opus 4.7+ and Sonnet 5 return an HTTP 400 if `temperature`/`top_p`/`top_k` are set to
+non-default values. `AnthropicBackendAdapter` detects these model families and omits the
+params automatically - no config needed, but don't rely on sampling-param overrides taking
+effect against these specific models.
 
 ## API Reference
 

--- a/packages/mcp/readme.md
+++ b/packages/mcp/readme.md
@@ -84,6 +84,41 @@ a browser-side agent) without any changes here - `mcp-query` ships `webMcpToolSe
 in-memory MCP-server shim you can plug into `new MCPClient({ servers: { page: webMcpToolServer() } })`.
 Any `MCPClient` built that way already satisfies `McpClientLike`.
 
+## Protocol versions
+
+`ai.matey.mcp` is protocol-version-agnostic by design: it never speaks MCP's wire protocol
+(JSON-RPC, transports, capability negotiation) itself — it only calls `client.listTools()` and
+`client.callTool()` through the `McpClientLike` structural interface. Whichever MCP protocol
+revision(s) the *injected client* negotiates are supported transparently, with zero code in this
+package caring about the difference.
+
+Concretely, for the reference client [`mcp-query`](https://github.com/johnhenry/mcp-query)
+(`@johnhenry/mcpq`), `ConnectionConfig` supports:
+
+| Revision | Era | Notes |
+|---|---|---|
+| `2025-11-25` | legacy (v1) | Classic `initialize` handshake, unsolicited notifications, `resources/subscribe`, optional session resumption. **Default** when neither `versions` nor `versionNegotiation` is set. |
+| `2026-07-28` | modern | `server/discover`-based negotiation, change notifications over a client-opened `subscriptions/listen` stream, no sessions/ping/`logging/setLevel`. |
+
+```typescript
+new MCPClient({
+  servers: {
+    // Default: legacy-only, no probe.
+    a: { transport },
+    // Additive: probe for modern, fall back losslessly to legacy.
+    b: { transport, versions: ['2026-07-28', '2025-11-25'] },
+    // Exclusive: pin to modern only - connect fails against a legacy-only server.
+    c: { transport, versions: ['2026-07-28'] },
+  },
+});
+```
+
+Unknown revision strings are passed through to the SDK verbatim, so a future MCP revision needs
+no change in `mcp-query` (or `ai.matey.mcp`) to support — only a new `versions` entry at the call
+site. If you inject a different `McpClientLike` implementation (the official SDK wrapped by hand,
+or your own), consult its docs for which revisions it negotiates; `ai.matey.mcp`'s behavior is
+identical either way.
+
 ## License
 
 MIT

--- a/packages/wrapper/readme.md
+++ b/packages/wrapper/readme.md
@@ -36,7 +36,7 @@ import { OpenAI } from 'ai.matey.wrapper';
 const client = new OpenAI({ backend: yourBackend });
 
 const response = await client.chat.completions.create({
-  model: 'gpt-4',
+  model: 'gpt-5.6-terra',
   messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```
@@ -49,7 +49,7 @@ import { Anthropic } from 'ai.matey.wrapper';
 const client = new Anthropic({ backend: yourBackend });
 
 const response = await client.messages.create({
-  model: 'claude-3-opus',
+  model: 'claude-sonnet-5',
   messages: [{ role: 'user', content: 'Hello!' }],
   max_tokens: 1024,
 });

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Provider-agnostic interface for AI APIs. Write once, run anywhere.
 
 ## Why ai.matey?
 
-**Same code, any provider.** Switch between OpenAI, Anthropic, Gemini, Ollama, and 20 other providers (24 total) without changing your application code.
+**Same code, any provider.** Switch between OpenAI, Anthropic, Gemini, Ollama, and 25 other providers (29 total) without changing your application code.
 
 ```typescript
 // Your code stays the same...


### PR DESCRIPTION
## Summary

A full sweep of the docs (root readme, EXAMPLES.md, docs/ROADMAP.md, CHANGELOG.md, and 6
package readmes) requested to verify everything is up to date for the recent release
candidates: structured output (#16), the CJS packaging fix (#23), the provider-refresh default
model bumps, the new `ai.matey.mcp` package, and the 5 new backend providers.

**Stale counts fixed:** provider count (24→29 in multiple places), package count (21→24),
source-file/LOC counts in ROADMAP.md, and ROADMAP's backend provider name list (was still
missing Inception Labs/Moonshot AI/SambaNova even after a prior pass).

**Stale examples fixed:** `packages/backend/readme.md`'s provider descriptions (GPT-4/Claude 3
Opus/Gemini Pro → current defaults), `packages/wrapper/readme.md`'s SDK example model names, a
broken `docs/API.md` link (actual file is lowercase `api.md`).

**Missing coverage added:**
- `packages/ai.matey.core/readme.md` didn't mention `runTools()`/`createRunTools` or
  `responseFormat` at all
- `packages/ai.matey.types/readme.md` didn't mention `IRResponseFormat`
- `packages/ai.matey.utils/readme.md` didn't mention its model-registry or schema/validation
  exports at all (readme was 100% stream-utilities focused)
- `responseFormat` had **zero example coverage** anywhere - added
  `examples/basic/structured-output.ts` + an EXAMPLES.md section. Along the way, discovered
  `responseFormat` is currently IR-level only (no frontend adapter translates it from a
  client-facing wire format yet), so the example correctly uses `bridge.executeIR()` rather
  than `bridge.chat()` - this is worth knowing if a frontend-level `responseFormat` translation
  is wanted later.
- `packages/mcp/readme.md` gets a new "Protocol versions" section per explicit request:
  `ai.matey.mcp` is protocol-version-agnostic (delegates entirely to the injected client), with
  `mcp-query`'s actual supported MCP revisions (2025-11-25 legacy/default, 2026-07-28 modern)
  documented as the reference client's behavior.

**ROADMAP.md's MCP section** also got corrected: it described `ai.matey.mcp` as unbuilt future
work with a different design (optional peer SDK dependency) than what actually shipped
(injectable-client, zero SDK dependency) - now marks the client as shipped and the server as
still not built.

No source code changes - docs, readmes, and one new example file only.

## Test plan
- [x] All 3 new/touched example files (`github-models.ts`, `dashscope.ts`, `structured-output.ts`) typecheck clean (`tsc --noEmit --strict`) against the workspace packages
- [x] Verified every model-name/count/API claim against source directly (grepped actual `defaultModel` fallbacks, actual export lists, actual `packages/` dir contents) rather than trusting the prior audit's paraphrase
- [x] Confirmed `responseFormat` is genuinely IR-only by checking `packages/frontend/src/adapters/openai.ts` has no `response_format` handling, then confirmed `bridge.executeIR()` exists as the correct bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)