### PR TITLE
Add OmniRoute backend adapter

### DIFF
--- a/.changeset/omniroute-provider.md
+++ b/.changeset/omniroute-provider.md
@@ -1,0 +1,11 @@
+---
+'ai.matey.backend': patch
+---
+
+Add `OmniRouteBackendAdapter` for [OmniRoute](https://github.com/diegosouzapw/OmniRoute), a
+self-hosted AI gateway fronting 290+ providers (90+ free) behind one OpenAI-compatible endpoint.
+Extends `OpenAIBackendAdapter` (same pattern as `LMStudioBackendAdapter`), since OmniRoute
+speaks the OpenAI wire format verbatim. Defaults to `http://localhost:20128/v1` and the special
+`auto` model (lets OmniRoute pick a healthy provider from your configured pool); no API key is
+required for local/keyless-free usage. `estimateCost()` returns `null` since the actual routed
+provider/cost isn't knowable from the request alone.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -290,9 +290,50 @@ npx tsx examples/basic/dashscope.ts
 
 ---
 
+### 6. OmniRoute (`basic/omniroute.ts`)
+
+A self-hosted gateway fronting 290+ providers (90+ free) behind one OpenAI-compatible
+endpoint - no API key required for keyless/local usage.
+
+**What it demonstrates:**
+- Using a local (not hosted-cloud) aggregator, unlike OpenRouter/Fireworks
+- The `auto` model - let OmniRoute pick a healthy provider from your pool
+
+**Code:**
+
+```typescript
+import { Bridge } from 'ai.matey.core';
+import { OpenAIFrontendAdapter } from 'ai.matey.frontend/openai';
+import { OmniRouteBackendAdapter } from 'ai.matey.backend/omniroute';
+
+async function main() {
+  const bridge = new Bridge(
+    new OpenAIFrontendAdapter(),
+    new OmniRouteBackendAdapter({
+      baseURL: 'http://localhost:20128/v1', // default OmniRoute port
+      apiKey: 'not-needed', // ignored for keyless local/free-provider usage
+    })
+  );
+
+  const response = await bridge.chat({
+    model: 'auto', // let OmniRoute pick a healthy provider from your configured pool
+    messages: [{ role: 'user', content: 'What is the capital of France?' }],
+  });
+
+  console.log('Response:', response);
+}
+```
+
+**Run:**
+```bash
+npx tsx examples/basic/omniroute.ts
+```
+
+---
+
 ## Structured Output
 
-### 6. Schema-Constrained JSON Output (`basic/structured-output.ts`)
+### 7. Schema-Constrained JSON Output (`basic/structured-output.ts`)
 
 Request JSON output that conforms to a schema, via `responseFormat` on `IRChatRequest`.
 
@@ -347,7 +388,7 @@ support matrix.
 
 ## Middleware
 
-### 7. Logging Middleware (`middleware/logging.ts`)
+### 8. Logging Middleware (`middleware/logging.ts`)
 
 Add logging to track requests and responses for debugging and monitoring.
 
@@ -406,7 +447,7 @@ npx tsx examples/middleware/logging.ts
 
 ---
 
-### 8. Retry Middleware (`middleware/retry.ts`)
+### 9. Retry Middleware (`middleware/retry.ts`)
 
 Automatic retry logic for failed requests with exponential backoff.
 
@@ -477,7 +518,7 @@ npx tsx examples/middleware/retry.ts
 
 ---
 
-### 9. Caching Middleware (`middleware/caching.ts`)
+### 10. Caching Middleware (`middleware/caching.ts`)
 
 Cache responses to reduce API calls and costs.
 
@@ -553,7 +594,7 @@ npx tsx examples/middleware/caching.ts
 
 ---
 
-### 10. Transform Middleware (`middleware/transform.ts`)
+### 11. Transform Middleware (`middleware/transform.ts`)
 
 Transform requests and responses (e.g., inject system messages).
 
@@ -611,7 +652,7 @@ npx tsx examples/middleware/transform.ts
 
 ---
 
-### 11. Middleware Chaining (`middleware-demo.ts`)
+### 12. Middleware Chaining (`middleware-demo.ts`)
 
 Demonstrates chaining multiple middleware together for powerful request/response processing.
 
@@ -630,7 +671,7 @@ npx tsx examples/middleware-demo.ts
 
 ## Routing
 
-### 12. Round-Robin Router (`routing/round-robin.ts`)
+### 13. Round-Robin Router (`routing/round-robin.ts`)
 
 Distribute requests across multiple backends for load balancing.
 
@@ -697,7 +738,7 @@ npx tsx examples/routing/round-robin.ts
 
 ---
 
-### 13. Fallback Router (`routing/fallback.ts`)
+### 14. Fallback Router (`routing/fallback.ts`)
 
 Automatic failover to backup backends when primary fails.
 
@@ -767,7 +808,7 @@ npx tsx examples/routing/fallback.ts
 
 ---
 
-### 14. Router with Model Translation (`routing/model-translation.ts`)
+### 15. Router with Model Translation (`routing/model-translation.ts`)
 
 Automatic model name translation during fallback for cross-provider compatibility.
 
@@ -888,7 +929,7 @@ npx tsx examples/routing/model-translation.ts
 
 ---
 
-### 15. Router with Per-Backend Translation (`routing/per-backend-translation.ts`)
+### 16. Router with Per-Backend Translation (`routing/per-backend-translation.ts`)
 
 Backend-specific model translation mappings that override global translations.
 
@@ -999,7 +1040,7 @@ npx tsx examples/routing/per-backend-translation.ts
 
 ---
 
-### 16. Capability-Based Routing (`routing/capability-based.ts`)
+### 17. Capability-Based Routing (`routing/capability-based.ts`)
 
 Automatically select backends based on model capabilities and requirements.
 
@@ -1092,7 +1133,7 @@ npx tsx examples/routing/capability-based.ts
 
 ---
 
-### 17. Cost-Optimized Routing (`routing/cost-optimized.ts`)
+### 18. Cost-Optimized Routing (`routing/cost-optimized.ts`)
 
 Automatically route to the cheapest backend that meets requirements.
 
@@ -1195,7 +1236,7 @@ npx tsx examples/routing/cost-optimized.ts
 
 ---
 
-### 18. Speed-Optimized Routing (`routing/speed-optimized.ts`)
+### 19. Speed-Optimized Routing (`routing/speed-optimized.ts`)
 
 Route to the fastest backend for low-latency applications.
 
@@ -1306,7 +1347,7 @@ npx tsx examples/routing/speed-optimized.ts
 
 ---
 
-### 19. Quality-Optimized Routing (`routing/quality-optimized.ts`)
+### 20. Quality-Optimized Routing (`routing/quality-optimized.ts`)
 
 Route to the highest quality models for critical tasks.
 
@@ -1419,7 +1460,7 @@ npx tsx examples/routing/quality-optimized.ts
 
 ## HTTP Servers
 
-### 20. Node.js HTTP Server (`http/node-server.ts`)
+### 21. Node.js HTTP Server (`http/node-server.ts`)
 
 Create a basic HTTP server using Node.js http module.
 
@@ -1498,7 +1539,7 @@ npx tsx examples/http/node-server.ts
 
 ---
 
-### 21. Express Server (`http/express-server.ts`)
+### 22. Express Server (`http/express-server.ts`)
 
 HTTP server using Express framework.
 
@@ -1559,7 +1600,7 @@ npx tsx examples/http/express-server.ts
 
 ---
 
-### 22. Hono Server (`http/hono-server.ts`)
+### 23. Hono Server (`http/hono-server.ts`)
 
 Lightweight HTTP server using Hono framework.
 
@@ -1577,7 +1618,7 @@ npx tsx examples/http/hono-server.ts
 
 ## SDK Wrappers
 
-### 23. OpenAI SDK Wrapper (`wrappers/openai-sdk.ts`)
+### 24. OpenAI SDK Wrapper (`wrappers/openai-sdk.ts`)
 
 Drop-in replacement for OpenAI SDK - use any backend!
 
@@ -1662,7 +1703,7 @@ npx tsx examples/wrappers/openai-sdk.ts
 
 ---
 
-### 24. Anthropic SDK Wrapper (`wrappers/anthropic-sdk.ts`)
+### 25. Anthropic SDK Wrapper (`wrappers/anthropic-sdk.ts`)
 
 Drop-in replacement for Anthropic SDK - use any backend!
 
@@ -1680,7 +1721,7 @@ npx tsx examples/wrappers/anthropic-sdk.ts
 
 ## Tool Calling
 
-### 25. Agentic Tool-Call Loop (`tools/run-tools.ts`)
+### 26. Agentic Tool-Call Loop (`tools/run-tools.ts`)
 
 `Bridge.runTools()` - execute → extract tool calls → run them → append results →
 re-execute, looping until the model answers or `maxIterations` is hit.
@@ -1711,7 +1752,7 @@ const result = await runMcpTools(bridge.runTools, {
 
 ## Browser APIs
 
-### 26. Chrome AI Language Model (`chrome-ai-wrapper.js`)
+### 27. Chrome AI Language Model (`chrome-ai-wrapper.js`)
 
 Mimic the Chrome AI API with any backend adapter.
 
@@ -1737,7 +1778,7 @@ node examples/chrome-ai-wrapper.js
 
 ---
 
-### 27. Legacy Chrome AI Wrapper (`chrome-ai-legacy-wrapper.js`)
+### 28. Legacy Chrome AI Wrapper (`chrome-ai-legacy-wrapper.js`)
 
 Support for the legacy Chrome AI API (pre-recent changes).
 
@@ -1764,7 +1805,7 @@ node examples/chrome-ai-legacy-wrapper.js
 
 ## Model Runners
 
-### 28. LlamaCpp Backend (`model-runner-llamacpp.ts`)
+### 29. LlamaCpp Backend (`model-runner-llamacpp.ts`)
 
 Run local GGUF models via llama.cpp binaries.
 

--- a/docs/IR-FORMAT.md
+++ b/docs/IR-FORMAT.md
@@ -788,7 +788,7 @@ Backends handle `responseFormat` one of two ways, reported via `IRCapabilities.s
 | OpenAI | Native (`response_format: { type: 'json_schema', json_schema: { schema } }`) |
 | Anthropic | Native (`output_config: { format: { type: 'json_schema', schema } }`) |
 | Gemini | Native (`generationConfig.responseSchema` + `responseMimeType: 'application/json'`) |
-| Groq, DeepSeek, Inception, Moonshot, NVIDIA, LM Studio, SambaNova | Native (OpenAI-compatible - inherit OpenAI's mapping unchanged) |
+| Groq, DeepSeek, Inception, Moonshot, NVIDIA, LM Studio, SambaNova, OmniRoute | Native (OpenAI-compatible - inherit OpenAI's mapping unchanged) |
 | All other backends (AI21, Anyscale, AWS Bedrock, Azure OpenAI, Cerebras, Cloudflare, Cohere, DeepInfra, Fireworks, Hugging Face, Mistral, Ollama, OpenRouter, Perplexity, Replicate, Together AI, xAI, GitHub Models, DashScope) | Fallback (prompt injection + best-effort JSON extraction) |
 
 ### Example

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,8 +23,8 @@ Development roadmap and strategic direction for the Universal AI Adapter System.
 - ✅ Provider-agnostic request/response handling
 
 ### Providers
-- ✅ **29 Backend Providers** in `ai.matey.backend`:
-  OpenAI, Anthropic, Gemini, Mistral, Cohere, Groq, Ollama, AI21, Anyscale, AWS Bedrock, Azure OpenAI, Cerebras, Cloudflare, DeepInfra, DeepSeek, Fireworks, HuggingFace, LMStudio, NVIDIA, OpenRouter, Perplexity, Replicate, Together AI, XAI, Inception Labs, Moonshot AI, SambaNova, GitHub Models, DashScope (Alibaba Cloud Model Studio)
+- ✅ **30 Backend Providers** in `ai.matey.backend`:
+  OpenAI, Anthropic, Gemini, Mistral, Cohere, Groq, Ollama, AI21, Anyscale, AWS Bedrock, Azure OpenAI, Cerebras, Cloudflare, DeepInfra, DeepSeek, Fireworks, HuggingFace, LMStudio, NVIDIA, OpenRouter, Perplexity, Replicate, Together AI, XAI, Inception Labs, Moonshot AI, SambaNova, GitHub Models, DashScope (Alibaba Cloud Model Studio), OmniRoute
 - ✅ **7 Frontend Adapters** in `ai.matey.frontend`:
   OpenAI, Anthropic, Gemini, Mistral, Ollama, Chrome AI, Generic
 - ✅ **3 Browser Backends** in `ai.matey.backend.browser`:
@@ -105,7 +105,7 @@ All 10 middleware types in `ai.matey.middleware`:
 - `ai.matey.core` - Bridge, Router, Middleware core
 
 ### Providers (3 packages)
-- `ai.matey.backend` - All 29 backend provider adapters
+- `ai.matey.backend` - All 30 backend provider adapters
 - `ai.matey.backend.browser` - Browser-only backends
 - `ai.matey.frontend` - All 7 frontend adapters
 
@@ -522,7 +522,7 @@ only via a structural `EmbeddingProvider = { embed() }`):
 
 ### Durable strengths to preserve
 
-Zero runtime dependencies; 29 backends with 7 routing strategies, circuit breaker, fallback and
+Zero runtime dependencies; 30 backends with 7 routing strategies, circuit breaker, fallback and
 parallel dispatch; 6 HTTP framework adapters with health/metrics/embeddings endpoints; the
 format-conversion CLI and OpenAI/Anthropic SDK shims; multi-format frontend adapters (few
 competitors can speak Anthropic's or Gemini's wire format into the same core).

--- a/examples/basic/omniroute.ts
+++ b/examples/basic/omniroute.ts
@@ -1,0 +1,40 @@
+/**
+ * OmniRoute Example
+ *
+ * OmniRoute (https://github.com/diegosouzapw/OmniRoute) is a self-hosted AI
+ * gateway fronting 290+ providers (90+ free) behind one OpenAI-compatible
+ * endpoint, with its own quota-aware auto-fallback across subscription/
+ * API-key/cheap/free provider tiers. Unlike ai.matey's other aggregators
+ * (OpenRouter, Fireworks), it's normally run locally with no API key
+ * required - `auto` already works on a fresh install.
+ */
+
+import { Bridge } from 'ai.matey.core';
+import { OpenAIFrontendAdapter } from 'ai.matey.frontend/openai';
+import { OmniRouteBackendAdapter } from 'ai.matey.backend/omniroute';
+
+async function main() {
+  const bridge = new Bridge(
+    new OpenAIFrontendAdapter(),
+    new OmniRouteBackendAdapter({
+      baseURL: 'http://localhost:20128/v1', // default OmniRoute port
+      // OmniRoute doesn't check this for keyless local/free-provider usage -
+      // any placeholder string works; BackendAdapterConfig just requires one.
+      apiKey: 'not-needed',
+    })
+  );
+
+  const response = await bridge.chat({
+    model: 'auto', // let OmniRoute pick a healthy provider from your configured pool
+    messages: [
+      {
+        role: 'user',
+        content: 'What is the capital of France?',
+      },
+    ],
+  });
+
+  console.log('Response:', response);
+}
+
+main().catch(console.error);

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -307,6 +307,16 @@
         "default": "./dist/cjs/providers/dashscope.js"
       }
     },
+    "./omniroute": {
+      "import": {
+        "types": "./dist/types/providers/omniroute.d.ts",
+        "default": "./dist/esm/providers/omniroute.js"
+      },
+      "require": {
+        "types": "./dist/types/providers/omniroute.d.ts",
+        "default": "./dist/cjs/providers/omniroute.js"
+      }
+    },
     "./shared": {
       "import": {
         "types": "./dist/types/shared.d.ts",

--- a/packages/backend/readme.md
+++ b/packages/backend/readme.md
@@ -12,7 +12,7 @@ npm install ai.matey.backend
 
 ## Included Providers
 
-This package includes adapters for **29 AI providers**:
+This package includes adapters for **30 AI providers**:
 
 ### Commercial APIs
 - **OpenAI** - GPT-5.6 family
@@ -54,6 +54,7 @@ This package includes adapters for **29 AI providers**:
 ### Local/Development
 - **Ollama** - Local model hosting
 - **LM Studio** - Local desktop inference
+- **OmniRoute** - Self-hosted gateway fronting 290+ providers (90+ free), no API key required by default
 
 For browser-compatible adapters (Chrome AI, Function, Mock), see [`ai.matey.backend.browser`](../backend-browser).
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -44,6 +44,7 @@ export * from './providers/moonshot.js';
 export * from './providers/sambanova.js';
 export * from './providers/github-models.js';
 export * from './providers/dashscope.js';
+export * from './providers/omniroute.js';
 
 // Note: The following adapters have been moved to ai.matey.backend.browser:
 // - chrome-ai (Chrome's built-in AI)

--- a/packages/backend/src/providers/omniroute.ts
+++ b/packages/backend/src/providers/omniroute.ts
@@ -1,0 +1,124 @@
+/**
+ * OmniRoute Backend Adapter
+ *
+ * Adapts Universal IR to OmniRoute's local OpenAI-compatible gateway
+ * (https://github.com/diegosouzapw/OmniRoute). OmniRoute is a self-hosted AI
+ * gateway that fronts 290+ providers (90+ with free tiers) behind one
+ * OpenAI-compatible endpoint, with its own quota-aware auto-fallback across
+ * subscription/API-key/cheap/free provider tiers.
+ *
+ * @module
+ */
+
+import { OpenAIBackendAdapter, type OpenAIRequest, type OpenAIResponse } from './openai.js';
+import type { BackendAdapter, BackendAdapterConfig, IRChatRequest } from 'ai.matey.types';
+
+/**
+ * Backend adapter for a self-hosted OmniRoute gateway.
+ *
+ * Unlike ai.matey's other aggregators (OpenRouter, Fireworks), OmniRoute is
+ * normally run locally with no API key required - a fresh install already
+ * answers requests against its keyless free-provider pool via the special
+ * `auto` model, which routes to a healthy provider automatically.
+ *
+ * @example Basic Usage
+ * ```typescript
+ * import { OmniRouteBackendAdapter } from 'ai.matey.backend/omniroute';
+ *
+ * const adapter = new OmniRouteBackendAdapter({
+ *   baseURL: 'http://localhost:20128/v1', // Default OmniRoute port
+ * });
+ *
+ * const response = await adapter.execute({
+ *   messages: [{ role: 'user', content: 'Hello!' }],
+ *   parameters: { model: 'auto' }, // Let OmniRoute pick a healthy free provider
+ * });
+ * ```
+ */
+export class OmniRouteBackendAdapter
+  extends OpenAIBackendAdapter
+  implements BackendAdapter<OpenAIRequest, OpenAIResponse>
+{
+  constructor(config: BackendAdapterConfig) {
+    const omnirouteConfig: BackendAdapterConfig = {
+      ...config,
+      baseURL: config.baseURL || 'http://localhost:20128/v1',
+      defaultModel: config.defaultModel || 'auto',
+      // OmniRoute doesn't require an API key for local/keyless-free usage
+      apiKey: config.apiKey || 'not-needed',
+    };
+
+    super(omnirouteConfig, {
+      name: 'omniroute-backend',
+      version: '1.0.0',
+      provider: 'OmniRoute',
+      capabilities: {
+        embeddings: true, // proxies OpenAI's /v1/embeddings too
+        maxEmbeddingBatchSize: 100,
+        streaming: true,
+        multiModal: true, // depends on the routed provider/model
+        tools: true, // depends on the routed provider/model
+        structuredOutput: 'native',
+        maxContextTokens: 128000, // varies widely by routed provider/model
+        systemMessageStrategy: 'in-messages',
+        supportsMultipleSystemMessages: false,
+        supportsTemperature: true,
+        supportsTopP: true,
+        supportsTopK: false,
+        supportsSeed: true,
+        supportsFrequencyPenalty: true,
+        supportsPresencePenalty: true,
+        maxStopSequences: 4,
+      },
+      config: {
+        baseURL: omnirouteConfig.baseURL,
+      },
+    });
+  }
+
+  /**
+   * Health check for OmniRoute. No auth required for local requests.
+   */
+  async healthCheck(): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.baseURL}/models`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        signal: AbortSignal.timeout(5000),
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Estimate cost. OmniRoute routes each request to one of 290+ providers
+   * (including free ones) based on its own quota/cost-aware fallback logic,
+   * so the actual cost isn't knowable from the request alone.
+   */
+  estimateCost(_request: IRChatRequest): Promise<number | null> {
+    return Promise.resolve(null);
+  }
+}
+
+/**
+ * Create an OmniRoute backend adapter.
+ *
+ * @param config - Adapter configuration
+ * @returns OmniRoute backend adapter
+ *
+ * @example Default Configuration
+ * ```typescript
+ * import { createOmniRouteAdapter } from 'ai.matey.backend/omniroute';
+ *
+ * const adapter = createOmniRouteAdapter({});
+ * ```
+ */
+export function createOmniRouteAdapter(
+  config: BackendAdapterConfig = {} as BackendAdapterConfig
+): OmniRouteBackendAdapter {
+  return new OmniRouteBackendAdapter(config);
+}

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Provider-agnostic interface for AI APIs. Write once, run anywhere.
 
 ## Why ai.matey?
 
-**Same code, any provider.** Switch between OpenAI, Anthropic, Gemini, Ollama, and 25 other providers (29 total) without changing your application code.
+**Same code, any provider.** Switch between OpenAI, Anthropic, Gemini, Ollama, and 26 other providers (30 total) without changing your application code.
 
 ```typescript
 // Your code stays the same...
@@ -424,6 +424,7 @@ import { OpenAIBackendAdapter } from 'ai.matey.backend/openai';
 - SambaNova
 - GitHub Models (free via any GitHub account)
 - Alibaba Cloud Model Studio / DashScope (Qwen)
+- OmniRoute (self-hosted gateway, 290+ providers, no API key required by default)
 
 **Browser-Compatible Package:** [`ai.matey.backend.browser`](./packages/backend-browser)
 

--- a/tests/unit/backend-adapters.test.ts
+++ b/tests/unit/backend-adapters.test.ts
@@ -9,6 +9,7 @@ import {
   SambaNovaBackendAdapter,
   GitHubModelsBackendAdapter,
   DashScopeBackendAdapter,
+  OmniRouteBackendAdapter,
 } from 'ai.matey.backend';
 import {
   MockBackendAdapter,
@@ -320,6 +321,51 @@ describe('Backend Adapters', () => {
 
     it('estimateCost returns null (pricing not consistently published)', async () => {
       const adapter = new DashScopeBackendAdapter({ apiKey: 'test-key' });
+
+      await expect(adapter.estimateCost(mockRequest)).resolves.toBeNull();
+    });
+  });
+
+  describe('OmniRouteBackendAdapter', () => {
+    const noKeyConfig = {} as ConstructorParameters<typeof OmniRouteBackendAdapter>[0];
+
+    it('should create adapter without an API key (local/keyless usage)', () => {
+      const adapter = new OmniRouteBackendAdapter(noKeyConfig);
+
+      expect(adapter).toBeDefined();
+      expect(adapter.metadata.name).toBe('omniroute-backend');
+    });
+
+    it('should provide metadata', () => {
+      const adapter = new OmniRouteBackendAdapter(noKeyConfig);
+      const metadata = adapter.metadata;
+
+      expect(metadata.name).toBe('omniroute-backend');
+      expect(metadata.provider).toBe('OmniRoute');
+      expect(metadata.capabilities.streaming).toBe(true);
+      expect(metadata.capabilities.tools).toBe(true);
+      expect(metadata.capabilities.embeddings).toBe(true);
+    });
+
+    it('should use the default local base URL and "auto" model', () => {
+      const adapter = new OmniRouteBackendAdapter(noKeyConfig);
+
+      expect(adapter.metadata.config?.baseURL).toBe('http://localhost:20128/v1');
+      const req = adapter.fromIR({ ...mockRequest, parameters: undefined });
+      expect(req.model).toBe('auto');
+    });
+
+    it('should accept a custom base URL and API key', () => {
+      const adapter = new OmniRouteBackendAdapter({
+        apiKey: 'test-key',
+        baseURL: 'http://localhost:8080/v1',
+      });
+
+      expect(adapter.metadata.config?.baseURL).toBe('http://localhost:8080/v1');
+    });
+
+    it('estimateCost returns null (actual routed provider/cost is unknowable from the request)', async () => {
+      const adapter = new OmniRouteBackendAdapter(noKeyConfig);
 
       await expect(adapter.estimateCost(mockRequest)).resolves.toBeNull();
     });


### PR DESCRIPTION
## Summary
- New `OmniRouteBackendAdapter` for [OmniRoute](https://github.com/diegosouzapw/OmniRoute) (27.5k stars, MIT, actively maintained) - a self-hosted AI gateway fronting 290+ providers (90+ free) behind one OpenAI-compatible endpoint
- Unlike ai.matey's other aggregators (OpenRouter, Fireworks), OmniRoute is normally run **locally** with no API key required by default, so this extends `OpenAIBackendAdapter` directly (same shape as `LMStudioBackendAdapter`) rather than the standalone-passthrough pattern used for hosted aggregators
- Defaults: `http://localhost:20128/v1` base URL, `auto` model (OmniRoute's own healthy-provider auto-selection)
- `estimateCost()` returns `null` - the actual routed provider/cost isn't knowable from the request alone
- Registered in `index.ts`, package.json subpath exports (`ai.matey.backend/omniroute`), backend + root readmes, `docs/ROADMAP.md`, and `docs/IR-FORMAT.md`'s structured-output matrix (listed as native, since it inherits `OpenAIBackendAdapter`'s mapping)
- New `examples/basic/omniroute.ts` + EXAMPLES.md entry
- Patch changeset for `ai.matey.backend`

## Test plan
- [x] 5 new tests in `tests/unit/backend-adapters.test.ts` (construction without an API key, metadata, default local baseURL + `auto` model via `fromIR`, custom baseURL/key, `estimateCost` returns null) - 76/76 passing
- [x] Full suite: 1512 passed / 11 skipped, 0 failures
- [x] `npx turbo run build` clean across the workspace
- [x] `npx turbo run lint --filter=ai.matey.backend` - 0 errors (same pre-existing warning pattern shared by every adapter)
- [x] New example file typechecks clean (`tsc --noEmit --strict`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)