### PR TITLE
Fix missing, stale, and non-lite default models across backend adapters

### DIFF
--- a/.changeset/provider-default-model-fixes.md
+++ b/.changeset/provider-default-model-fixes.md
@@ -1,0 +1,46 @@
+---
+'ai.matey.backend': minor
+---
+
+Fix missing, stale, and non-lite default models across the backend provider adapters.
+
+**Missing/broken defaults** (adapter had no sensible fallback at all):
+- `NVIDIABackendAdapter` and `LMStudioBackendAdapter` set no `defaultModel`, so an unspecified
+  request silently inherited `OpenAIBackendAdapter`'s `gpt-5.6-terra` fallback via subclassing - a
+  model neither NVIDIA NIM nor a local LM Studio server serves. Now default to
+  `meta/llama-3.1-8b-instruct` and `local-model` respectively.
+- `HuggingFaceBackendAdapter` had no fallback at all (sent an empty model string). Now defaults to
+  the ungated `Qwen/Qwen3.5-9B` (Meta's Llama repos require accepting a gated license, which would
+  break a default that's supposed to "just work").
+- `OllamaBackendAdapter`'s `fromIR` ignored `config.defaultModel` entirely and always fell back to
+  the retired `llama2`. Now respects `config.defaultModel` and falls back to `llama3.2`.
+
+**Retired model IDs** (still accepted the old default, but the model itself is gone):
+- `AnyscaleBackendAdapter` / `ReplicateBackendAdapter`: Llama 2 (2023) → Llama 3.1/3 8B Instruct.
+- `PerplexityBackendAdapter`: `llama-3.1-sonar-small-128k-online` (retired when Perplexity renamed
+  to the plain `sonar` family) → `sonar`.
+- `AWSBedrockBackendAdapter`: `anthropic.claude-3-haiku-20240307-v1:0` (2024) →
+  `global.anthropic.claude-haiku-4-5-20251001-v1:0`. The bare Haiku 4.5 model ID 400s on Bedrock
+  ("on-demand throughput isn't supported for this model") - it must go through the `global.`
+  cross-region inference profile.
+
+**Mid-tier → lite-tier bumps** (default worked fine, but pointed at the balanced/flagship tier
+instead of the provider's cheaper lite tier - verified live against each platform's current docs
+on 2026-08-01, not assumed):
+- OpenAI: `gpt-5.6-terra` (balanced) → `gpt-5.6-luna` (fast, low-cost tier).
+- Anthropic: `claude-sonnet-5` → `claude-haiku-4-5-20251001` (lightweight tier; also updates the
+  `estimateCost()` fallback rate from a Sonnet-tier $3.00/1M to Haiku's actual $1.00/1M).
+- Groq: `llama-3.3-70b-versatile` → `llama-3.1-8b-instant` (Groq's cheapest/fastest tier).
+- DashScope: `qwen3.7-plus` (mid) → `qwen3.7-flash` (budget tier).
+
+**Deliberately left unchanged** (no reliable lite alternative found):
+- xAI's `grok-4.5` - xAI's own docs describe it as "the most intelligent and fastest model," with
+  no distinct cheaper tier confirmed live in the current model lineup.
+- Together AI's `deepseek-ai/DeepSeek-V4-Pro` - `DeepSeek-V4-Flash` exists on other platforms but
+  Together AI's own blog still lists it as "coming soon," not yet live there.
+- Azure OpenAI's `gpt-4o` deployment-name guess - Azure deployment IDs are arbitrary names the
+  resource owner chose, not a selectable provider model list, so there's no reliable lite
+  equivalent to guess at.
+- Mistral, Cohere, AI21, Cerebras, Cloudflare, GitHub Models, OpenRouter, Fireworks, DeepInfra,
+  Gemini, Moonshot, DeepSeek, SambaNova, Inception - already default to their smallest documented
+  tier.

--- a/packages/backend/src/providers/anthropic.ts
+++ b/packages/backend/src/providers/anthropic.ts
@@ -533,9 +533,10 @@ export class AnthropicBackendAdapter implements BackendAdapter<
     // Use shared token estimation utility
     const estimatedInputTokens = estimateTokens(request);
     // Price the requested model via the shared registry; fall back to a
-    // representative Sonnet-tier rate when the model is unknown
-    const model = request.parameters?.model || this.config.defaultModel || 'claude-sonnet-5';
-    const inputPer1M = getModelPricingInfo(model)?.inputPer1M ?? 3.0;
+    // representative Haiku-tier rate when the model is unknown
+    const model =
+      request.parameters?.model || this.config.defaultModel || 'claude-haiku-4-5-20251001';
+    const inputPer1M = getModelPricingInfo(model)?.inputPer1M ?? 1.0;
     return Promise.resolve((estimatedInputTokens / 1_000_000) * inputPer1M);
   }
 
@@ -592,7 +593,8 @@ export class AnthropicBackendAdapter implements BackendAdapter<
 
       // Claude Opus 4.7+ (incl. 4.8) and Sonnet 5 return HTTP 400 if sampling
       // params are set to a non-default value - omit them for those models.
-      const model = request.parameters?.model || this.config.defaultModel || 'claude-sonnet-5';
+      const model =
+        request.parameters?.model || this.config.defaultModel || 'claude-haiku-4-5-20251001';
       const allowSamplingParams = supportsSamplingParams(model);
 
       // Build Anthropic request
@@ -707,7 +709,9 @@ export class AnthropicBackendAdapter implements BackendAdapter<
       // supportsSamplingParams - Opus 4.7+/4.8 and Sonnet 5 return HTTP 400
       // if these are set to a non-default value).
       const model =
-        originalRequest.parameters?.model || this.config.defaultModel || 'claude-sonnet-5';
+        originalRequest.parameters?.model ||
+        this.config.defaultModel ||
+        'claude-haiku-4-5-20251001';
       const droppedSamplingParams =
         !supportsSamplingParams(model) &&
         (originalRequest.parameters?.temperature !== undefined ||

--- a/packages/backend/src/providers/anyscale.ts
+++ b/packages/backend/src/providers/anyscale.ts
@@ -171,7 +171,9 @@ export class AnyscaleBackendAdapter implements BackendAdapter<AnyscaleRequest, A
 
     return {
       model:
-        request.parameters?.model || this.config.defaultModel || 'meta-llama/Llama-2-70b-chat-hf',
+        request.parameters?.model ||
+        this.config.defaultModel ||
+        'meta-llama/Meta-Llama-3.1-8B-Instruct',
       messages: anyscaleMessages,
       temperature: request.parameters?.temperature,
       max_tokens: request.parameters?.maxTokens,

--- a/packages/backend/src/providers/aws-bedrock.ts
+++ b/packages/backend/src/providers/aws-bedrock.ts
@@ -202,9 +202,13 @@ export class AWSBedrockBackendAdapter implements BackendAdapter<BedrockRequest, 
 
     const bedrockRequest: BedrockRequest = {
       modelId:
+        // Claude Haiku 4.5 has no on-demand throughput on Bedrock - the bare
+        // 'anthropic.claude-haiku-4-5-...' model ID 400s with "on-demand
+        // throughput isn't supported for this model". It must be invoked
+        // through the 'global.' cross-region inference profile instead.
         request.parameters?.model ||
         this.config.defaultModel ||
-        'anthropic.claude-3-haiku-20240307-v1:0',
+        'global.anthropic.claude-haiku-4-5-20251001-v1:0',
       messages: bedrockMessages,
       inferenceConfig: {
         temperature: request.parameters?.temperature,

--- a/packages/backend/src/providers/dashscope.ts
+++ b/packages/backend/src/providers/dashscope.ts
@@ -188,7 +188,7 @@ export class DashScopeBackendAdapter implements BackendAdapter<
     }));
 
     return {
-      model: request.parameters?.model || this.config.defaultModel || 'qwen3.7-plus',
+      model: request.parameters?.model || this.config.defaultModel || 'qwen3.7-flash',
       messages: dashScopeMessages,
       temperature: request.parameters?.temperature,
       max_tokens: request.parameters?.maxTokens,

--- a/packages/backend/src/providers/groq.ts
+++ b/packages/backend/src/providers/groq.ts
@@ -64,7 +64,7 @@ export class GroqBackendAdapter
     const groqConfig: BackendAdapterConfig = {
       ...config,
       baseURL: config.baseURL || 'https://api.groq.com/openai/v1',
-      defaultModel: config.defaultModel || 'llama-3.3-70b-versatile',
+      defaultModel: config.defaultModel || 'llama-3.1-8b-instant',
     };
 
     // Pass Groq-specific metadata to parent constructor

--- a/packages/backend/src/providers/huggingface.ts
+++ b/packages/backend/src/providers/huggingface.ts
@@ -158,7 +158,15 @@ export class HuggingFaceBackendAdapter implements BackendAdapter<
 
       // Make HTTP request
       const startTime = Date.now();
-      const response = await this.makeRequest(request.parameters?.model || '', hfRequest, signal);
+      const response = await this.makeRequest(
+        // Meta's Llama repos require accepting a gated license on HF, which
+        // breaks a default that's supposed to "just work". Qwen3.5-9B is
+        // ungated (Apache 2.0) and matches the ~8B-class lite tier other
+        // aggregator adapters in this file default to.
+        request.parameters?.model || this.config.defaultModel || 'Qwen/Qwen3.5-9B',
+        hfRequest,
+        signal
+      );
 
       // Convert response to IR
       const irResponse = this.toIR(response, request, Date.now() - startTime);

--- a/packages/backend/src/providers/lmstudio.ts
+++ b/packages/backend/src/providers/lmstudio.ts
@@ -66,6 +66,12 @@ export class LMStudioBackendAdapter
       baseURL: config.baseURL || 'http://localhost:1234/v1',
       // LM Studio doesn't require API key for local usage
       apiKey: config.apiKey || 'not-needed',
+      // Without this, the adapter silently inherits OpenAIBackendAdapter's
+      // 'gpt-5.6-terra' fallback, which no local LM Studio server serves.
+      // There's no cloud "flagship" here - LM Studio ignores this value for
+      // single-model setups and otherwise expects the id of whatever model
+      // the user has loaded locally.
+      defaultModel: config.defaultModel || 'local-model',
     };
 
     // Pass LM Studio-specific metadata to parent constructor

--- a/packages/backend/src/providers/nvidia.ts
+++ b/packages/backend/src/providers/nvidia.ts
@@ -73,6 +73,9 @@ export class NVIDIABackendAdapter
     const nvidiaConfig: BackendAdapterConfig = {
       ...config,
       baseURL: config.baseURL || 'https://integrate.api.nvidia.com/v1',
+      // Without this, the adapter silently inherits OpenAIBackendAdapter's
+      // 'gpt-5.6-terra' fallback, which NVIDIA NIM does not serve.
+      defaultModel: config.defaultModel || 'meta/llama-3.1-8b-instruct',
     };
 
     // Pass NVIDIA-specific metadata to parent constructor

--- a/packages/backend/src/providers/ollama.ts
+++ b/packages/backend/src/providers/ollama.ts
@@ -347,7 +347,7 @@ export class OllamaBackendAdapter implements BackendAdapter<OllamaRequest, Ollam
     }));
 
     return {
-      model: request.parameters?.model || 'llama2',
+      model: request.parameters?.model || this.config.defaultModel || 'llama3.2',
       messages: ollamaMessages,
       options: {
         temperature: request.parameters?.temperature,

--- a/packages/backend/src/providers/openai.ts
+++ b/packages/backend/src/providers/openai.ts
@@ -562,7 +562,7 @@ export class OpenAIBackendAdapter implements BackendAdapter<OpenAIRequest, OpenA
     const estimatedInputTokens = estimateTokens(request);
     // Price the requested model via the shared registry; fall back to the
     // flagship gpt-5.x input rate when the model is unknown
-    const model = request.parameters?.model || this.config.defaultModel || 'gpt-5.6-terra';
+    const model = request.parameters?.model || this.config.defaultModel || 'gpt-5.6-luna';
     const inputPer1M = getModelPricingInfo(model)?.inputPer1M ?? 1.25;
     return Promise.resolve((estimatedInputTokens / 1_000_000) * inputPer1M);
   }
@@ -723,7 +723,7 @@ export class OpenAIBackendAdapter implements BackendAdapter<OpenAIRequest, OpenA
       );
 
       // Build OpenAI request
-      const model = request.parameters?.model || this.config.defaultModel || 'gpt-5.6-terra';
+      const model = request.parameters?.model || this.config.defaultModel || 'gpt-5.6-luna';
       const openaiRequest: OpenAIRequest = {
         model,
         messages: openaiMessages,

--- a/packages/backend/src/providers/perplexity.ts
+++ b/packages/backend/src/providers/perplexity.ts
@@ -181,9 +181,9 @@ export class PerplexityBackendAdapter implements BackendAdapter<
 
     const perplexityRequest: PerplexityRequest = {
       model:
-        request.parameters?.model ||
-        this.config.defaultModel ||
-        'llama-3.1-sonar-small-128k-online',
+        // 'llama-3.1-sonar-*-online' models were retired when Perplexity
+        // renamed its lineup to the plain 'sonar' family.
+        request.parameters?.model || this.config.defaultModel || 'sonar',
       messages: perplexityMessages,
       temperature: request.parameters?.temperature,
       max_tokens: request.parameters?.maxTokens,

--- a/packages/backend/src/providers/replicate.ts
+++ b/packages/backend/src/providers/replicate.ts
@@ -164,7 +164,7 @@ export class ReplicateBackendAdapter implements BackendAdapter<
 
     return {
       version:
-        request.parameters?.model || this.config.defaultModel || 'meta/llama-2-70b-chat:latest',
+        request.parameters?.model || this.config.defaultModel || 'meta/meta-llama-3-8b-instruct',
       input,
       stream: request.stream || false,
     };

--- a/tests/unit/backend-anthropic-sampling-params.test.ts
+++ b/tests/unit/backend-anthropic-sampling-params.test.ts
@@ -63,10 +63,10 @@ describe('Anthropic backend sampling param mapping', () => {
     expect(req.top_k).toBe(40);
   });
 
-  it('uses the new claude-sonnet-5 default, so sampling params are omitted with no explicit model', () => {
+  it('uses the claude-haiku-4-5 default, which still supports sampling params, with no explicit model', () => {
     const req = adapter.fromIR(makeRequest({ parameters: { temperature: 0.7, topP: 0.9, topK: 40 } }));
-    expect(req.model).toBe('claude-sonnet-5');
-    expect(req.temperature).toBeUndefined();
+    expect(req.model).toBe('claude-haiku-4-5-20251001');
+    expect(req.temperature).toBe(0.7);
   });
 
   it('adds a parameter-unsupported warning when sampling params are dropped', () => {

--- a/tests/unit/backend-default-model-fixes.test.ts
+++ b/tests/unit/backend-default-model-fixes.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression tests for default-model gaps/staleness fixed across the
+ * backend provider adapters: some had no default at all (silently
+ * inheriting OpenAIBackendAdapter's default via subclassing), others
+ * still pointed at models retired years ago (Llama 2, Claude 3 Haiku,
+ * the old Perplexity llama-3.1-sonar-* lineup), and some pointed at their
+ * mid/balanced tier rather than the cheaper lite tier the provider also
+ * offers (Groq, DashScope - verified live against each platform's current
+ * pricing/model docs on 2026-08-01).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  NVIDIABackendAdapter,
+  LMStudioBackendAdapter,
+  OllamaBackendAdapter,
+  AnyscaleBackendAdapter,
+  PerplexityBackendAdapter,
+  AWSBedrockBackendAdapter,
+  ReplicateBackendAdapter,
+  GroqBackendAdapter,
+  DashScopeBackendAdapter,
+} from 'ai.matey.backend';
+import type { IRChatRequest } from 'ai.matey.types';
+
+function makeRequest(overrides: Partial<IRChatRequest> = {}): IRChatRequest {
+  return {
+    messages: [{ role: 'user', content: 'hi' }],
+    parameters: {},
+    metadata: { requestId: 'req-1', timestamp: Date.now(), provenance: {} },
+    ...overrides,
+  };
+}
+
+describe('NVIDIA default model', () => {
+  it('does not inherit OpenAIBackendAdapter default (gpt-5.6-terra is not a NIM model)', () => {
+    const adapter = new NVIDIABackendAdapter({ apiKey: 'test-key' });
+    const req = adapter.fromIR(makeRequest());
+    expect(req.model).toBe('meta/llama-3.1-8b-instruct');
+  });
+});
+
+describe('LM Studio default model', () => {
+  it('does not inherit OpenAIBackendAdapter default (no local server serves gpt-5.6-terra)', () => {
+    const adapter = new LMStudioBackendAdapter({});
+    const req = adapter.fromIR(makeRequest());
+    expect(req.model).toBe('local-model');
+  });
+});
+
+describe('Ollama default model', () => {
+  it('respects config.defaultModel instead of always sending llama2', () => {
+    const adapter = new OllamaBackendAdapter({ defaultModel: 'llama3.2' });
+    const req = adapter.fromIR(makeRequest());
+    expect(req.model).toBe('llama3.2');
+  });
+
+  it('falls back to llama3.2, not the retired llama2', () => {
+    const adapter = new OllamaBackendAdapter({});
+    const req = adapter.fromIR(makeRequest());
+    expect(req.model).toBe('llama3.2');
+  });
+});
+
+describe('Anyscale default model', () => {
+  it('defaults to a Llama 3.1 model, not the retired Llama 2', () => {
+    const adapter = new AnyscaleBackendAdapter({ apiKey: 'test-key' });
+    const req = adapter.fromIR(makeRequest());
+    expect(req.model).toBe('meta-llama/Meta-Llama-3.1-8B-Instruct');
+  });
+});
+
+describe('Perplexity default model', () => {
+  it('defaults to sonar, not the retired llama-3.1-sonar-*-online lineup', () => {
+    const adapter = new PerplexityBackendAdapter({ apiKey: 'test-key' });
+    const req = adapter.fromIR(makeRequest());
+    expect(req.model).toBe('sonar');
+  });
+});
+
+describe('AWS Bedrock default model', () => {
+  it('defaults to the Claude Haiku 4.5 global inference profile, not Claude 3 Haiku', () => {
+    const adapter = new AWSBedrockBackendAdapter({});
+    const req = adapter.fromIR(makeRequest());
+    // Bare 'anthropic.claude-haiku-4-5-...' 400s with "on-demand throughput
+    // isn't supported for this model" - it must go through the 'global.'
+    // cross-region inference profile.
+    expect(req.modelId).toBe('global.anthropic.claude-haiku-4-5-20251001-v1:0');
+  });
+});
+
+describe('Replicate default model', () => {
+  it('defaults to Llama 3 8B Instruct, not the retired Llama 2 70B', () => {
+    const adapter = new ReplicateBackendAdapter({ apiKey: 'test-key' });
+    const req = adapter.fromIR(makeRequest());
+    expect(req.version).toBe('meta/meta-llama-3-8b-instruct');
+  });
+});
+
+describe('Groq default model', () => {
+  it('defaults to the cheap/fast Llama 3.1 8B Instant tier, not the 70B versatile tier', () => {
+    const adapter = new GroqBackendAdapter({ apiKey: 'test-key' });
+    const req = adapter.fromIR(makeRequest());
+    expect(req.model).toBe('llama-3.1-8b-instant');
+  });
+});
+
+describe('DashScope default model', () => {
+  it('defaults to the qwen3.7-flash budget tier, not the qwen3.7-plus mid tier', () => {
+    const adapter = new DashScopeBackendAdapter({ apiKey: 'test-key' });
+    const req = adapter.fromIR(makeRequest());
+    expect(req.model).toBe('qwen3.7-flash');
+  });
+});

--- a/tests/unit/backend-max-completion-tokens.test.ts
+++ b/tests/unit/backend-max-completion-tokens.test.ts
@@ -61,14 +61,14 @@ describe('OpenAI backend max_tokens vs max_completion_tokens mapping', () => {
   });
 
   it('sends max_tokens for the fallback default model', () => {
-    // Default model is 'gpt-5.6-terra' when neither the request nor config
+    // Default model is 'gpt-5.6-luna' when neither the request nor config
     // specify one - it must also take the max_completion_tokens path.
     const req = adapter.fromIR({
       messages: [{ role: 'user', content: 'hi' }],
       parameters: { maxTokens: 100 },
       metadata: { requestId: 'req-1', timestamp: Date.now(), provenance: {} },
     });
-    expect(req.model).toBe('gpt-5.6-terra');
+    expect(req.model).toBe('gpt-5.6-luna');
     expect(req.max_completion_tokens).toBe(100);
     expect(req.max_tokens).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

- **Missing/broken defaults**: NVIDIA and LM Studio had no `defaultModel` at all and silently inherited `OpenAIBackendAdapter`'s fallback via subclassing (a model neither serves). Hugging Face sent an empty model string when unset. Ollama's `fromIR` ignored `config.defaultModel` entirely.
- **Retired model IDs**: Anyscale/Replicate still pointed at Llama 2 (2023). Perplexity still pointed at the retired `llama-3.1-sonar-small-128k-online`. AWS Bedrock still pointed at Claude 3 Haiku (2024) — bumped to the Claude Haiku 4.5 `global.` cross-region inference profile (the bare model ID 400s on Bedrock now).
- **Mid-tier → lite-tier bumps**: OpenAI, Anthropic, Groq, and DashScope defaulted to their balanced/mid tier rather than the cheaper lite tier the provider also offers.
- Deliberately left unchanged where no reliable lite alternative exists: xAI, Together AI, Azure OpenAI (see changeset for reasoning), and providers that already defaulted to their smallest documented tier.

All defaults verified live against each provider's current docs/pricing pages (WebSearch/WebFetch), not assumed from training data.

## Test plan

- [x] `npm run lint` / `npm run format:check` pass
- [x] `npm run typecheck` passes
- [x] `npm run build` passes (all 24 workspace packages)
- [x] `npx vitest run` — 1522 passed, 11 skipped
- [x] Updated 2 existing tests whose assertions were pinned to the old Anthropic/OpenAI defaults
- [x] Added `tests/unit/backend-default-model-fixes.test.ts` covering 9 of the changed providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)